### PR TITLE
Adds unit tests for all BulkRename operations

### DIFF
--- a/Assets/RedBlueGames/BulkRename/BulkRenamer.cs
+++ b/Assets/RedBlueGames/BulkRename/BulkRenamer.cs
@@ -41,7 +41,7 @@ namespace RedBlueGames.Tools
         {
             this.Prefix = string.Empty;
             this.Suffix = string.Empty;
-            this.SearchToken = string.Empty;
+            this.SearchString = string.Empty;
             this.ReplacementString = string.Empty;
         }
 
@@ -58,10 +58,10 @@ namespace RedBlueGames.Tools
         public string Suffix { get; set; }
 
         /// <summary>
-        /// Gets or sets the search token, used to determine what text to replace.
+        /// Gets or sets the search string, used to determine what text to replace.
         /// </summary>
-        /// <value>The search token.</value>
-        public string SearchToken { get; set; }
+        /// <value>The search string.</value>
+        public string SearchString { get; set; }
 
         /// <summary>
         /// Gets or sets the replacement string, which replaces instances of the search token.
@@ -98,7 +98,7 @@ namespace RedBlueGames.Tools
             get
             {
                 return string.Concat(
-                    ColorStringForDelete(this.SearchToken),
+                    ColorStringForDelete(this.SearchString),
                     ColorStringForAdd(this.ReplacementString));
             }
         }
@@ -149,11 +149,11 @@ namespace RedBlueGames.Tools
             }
 
             // Replace strings first so we don't replace the prefix.
-            if (!string.IsNullOrEmpty(this.SearchToken))
+            if (!string.IsNullOrEmpty(this.SearchString))
             {
                 var replacementString = showDiff ? this.ColoredReplacementString :
                 this.ReplacementString;
-                modifiedName = modifiedName.Replace(this.SearchToken, replacementString);
+                modifiedName = modifiedName.Replace(this.SearchString, replacementString);
             }
 
             if (!string.IsNullOrEmpty(this.Prefix))
@@ -170,13 +170,21 @@ namespace RedBlueGames.Tools
 
             if (!string.IsNullOrEmpty(this.CountFormat))
             {
-                var countAsString = this.Count.ToString(this.CountFormat);
-                if (showDiff)
+                try
                 {
-                    countAsString = string.Concat(ColorStringForAdd(countAsString));
-                }
+                    var countAsString = this.Count.ToString(this.CountFormat);
 
-                modifiedName = string.Concat(modifiedName, countAsString);
+                    if (showDiff)
+                    {
+                        countAsString = string.Concat(ColorStringForAdd(countAsString));
+                    }
+
+                    modifiedName = string.Concat(modifiedName, countAsString);
+                }
+                catch (System.FormatException)
+                {
+                    // Can't append anything if format is bad.
+                }
             }
 
             return modifiedName;

--- a/Assets/RedBlueGames/BulkRename/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/BulkRenamerWindow.cs
@@ -118,9 +118,9 @@ namespace RedBlueGames.Tools
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Text Replacement", EditorStyles.boldLabel);
-            this.bulkRenamer.SearchToken = EditorGUILayout.TextField(
-                "Search Token",
-                this.bulkRenamer.SearchToken);
+            this.bulkRenamer.SearchString = EditorGUILayout.TextField(
+                "Search for String",
+                this.bulkRenamer.SearchString);
             this.bulkRenamer.ReplacementString = EditorGUILayout.TextField(
                 "Replace with",
                 this.bulkRenamer.ReplacementString);
@@ -145,6 +145,20 @@ namespace RedBlueGames.Tools
             this.bulkRenamer.CountFormat = EditorGUILayout.TextField(
                 "Count Format",
                 this.bulkRenamer.CountFormat);
+            
+            try
+            {
+                this.startingCount.ToString(this.bulkRenamer.CountFormat);
+            }
+            catch (System.FormatException)
+            {
+                var helpBoxMessage = "Invalid Count Format. Typical formats are D1 for one digit with no " +
+                                     "leading zeros, D2, for two, etc." +
+                                     "\nSee https://msdn.microsoft.com/en-us/library/dwhawy9k(v=vs.110).aspx" +
+                                     " for more formatting options.";
+                EditorGUILayout.HelpBox(helpBoxMessage, MessageType.Warning);
+            }
+
             this.startingCount = EditorGUILayout.IntField("Count From", this.startingCount);
 
             if (GUILayout.Button("Rename"))

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor.meta
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9c336f3d7d3554404950ddfdc5021988
+folderAsset: yes
+timeCreated: 1480087262
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
@@ -1,0 +1,379 @@
+﻿namespace RedBlueGames.Tools.Tests
+{
+    using System.Collections;
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class BulkRenamerUnitTests
+    {
+        [Test]
+        public void SearchString_Empty_DoesNothing()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            bulkRenamer.SearchString = string.Empty;
+            var validInput = "ThisIsAName";
+            var originalInput = validInput;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(validInput, false);
+
+            // Assert
+            Assert.AreEqual(originalInput, result);
+        }
+
+        [Test]
+        public void SearchString_OneMatch_IsReplaced()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            bulkRenamer.SearchString = "Hero";
+            var name = "CHAR_Hero_Spawn";
+            var expected = "CHAR__Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchString_DoesNotMatchCase_DoesNotReplace()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "ZELDA";
+            bulkRenamer.SearchString = name.ToLower();
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchString_MutlipleMatches_AllAreReplaced()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "StoolDoodad";
+            bulkRenamer.SearchString = "o";
+            var expected = "StlDdad";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchString_PartialMatches_AreNotReplaced()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Spawn";
+            bulkRenamer.SearchString = "Heroine";
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchString_Replacement_SubstitutesForSearchString()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Spawn";
+            bulkRenamer.SearchString = "Hero";
+            bulkRenamer.ReplacementString = "Link";
+            var expected = "Char_Link_Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void AddPrefix_Empty_DoesNothing()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Spawn";
+            bulkRenamer.Prefix = string.Empty;
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void AddPrefix_ValidPrefix_IsAdded()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Hero_Spawn";
+            bulkRenamer.Prefix = "Char_";
+            var expected = "Char_Hero_Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void AddSuffix_Empty_DoesNothing()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Spawn";
+            bulkRenamer.Prefix = string.Empty;
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void AddSuffix_ValidPrefix_IsAdded()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.Suffix = "_Spawn";
+            var expected = "Char_Hero_Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteNone_IsUnchanged()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = 0;
+            bulkRenamer.NumBackDeleteChars = 0;
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteOneFromFront_IsDeleted()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = 1;
+            bulkRenamer.NumBackDeleteChars = 0;
+            var expected = "har_Hero";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteOneFromBack_IsDeleted()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = 0;
+            bulkRenamer.NumBackDeleteChars = 1;
+            var expected = "Char_Her";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteFromFrontAndBack_IsDeleted()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = 1;
+            bulkRenamer.NumBackDeleteChars = 1;
+            var expected = "har_Her";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteLongerThanString_EntireStringIsDeleted()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = name.Length + 2;
+            bulkRenamer.NumBackDeleteChars = 0;
+            var expected = string.Empty;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteTooManyFromBothDirections_EntireStringIsDeleted()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = name.Length;
+            bulkRenamer.NumBackDeleteChars = name.Length;
+            var expected = string.Empty;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Trimming_DeleteNegative_IsUnchanged()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.NumFrontDeleteChars = -1;
+            bulkRenamer.NumBackDeleteChars = -10;
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Enumerating_NoFormat_DoesNothing()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.CountFormat = string.Empty;
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Enumerating_SingleDigitFormat_AddsCount()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.CountFormat = "0";
+            bulkRenamer.Count = 0;
+            var expected = "Char_Hero0";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Enumerating_StartFromNonZero_AddsCorrectCount()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.CountFormat = "0";
+            bulkRenamer.Count = -1;
+            var expected = "Char_Hero-1";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Enumerating_InvalidFormat_IsIgnored()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero";
+            bulkRenamer.CountFormat = "s";
+            bulkRenamer.Count = 100;
+            var expected = "Char_Hero";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void AllOperations_ValidOperations_RenamesCorrectly()
+        {
+            // Arrange
+            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Idle";
+            bulkRenamer.SearchString = "r_H";
+            bulkRenamer.ReplacementString = "t_Z";
+            bulkRenamer.NumFrontDeleteChars = 1;
+            bulkRenamer.NumBackDeleteChars = 5;
+            bulkRenamer.Prefix = "a_";
+            bulkRenamer.Suffix = "AA";
+            bulkRenamer.CountFormat = "D4";
+            bulkRenamer.Count = 100;
+            var expected = "a_hat_ZeroAA0100";
+
+            // Act
+            string result = bulkRenamer.GetRenamedString(name, false);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cd9c00a9fa7184292b5a4398f4ea13ee
+timeCreated: 1480087188
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes Issue #12.

This is a combination of 5 commits:
* Add Unit tests for Search string
* Add tests for Prefix and Suffix appending
* Add tests for deleting from front and back
* Add enumeration unit tests and error handling for bad format
* Add test that combines all operations at once