### PR TITLE
Rework GUI to allow users to add any number of rename operations

### DIFF
--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
@@ -23,8 +23,7 @@ SOFTWARE.
 
 namespace RedBlueGames.BulkRename
 {
-    using System.Collections;
-    using System.Text.RegularExpressions;
+    using System.Collections.Generic;
     using UnityEngine;
 
     /// <summary>
@@ -32,29 +31,33 @@ namespace RedBlueGames.BulkRename
     /// </summary>
     public class BulkRenamer
     {
-        /// <summary>
-        /// Gets or sets the ReplaceStringOp.
-        /// </summary>
-        /// <value>The replace string op.</value>
-        public ReplaceStringOperation ReplaceStringOp { get; set; }
+        private List<IRenameOperation> renameOperations;
 
-        /// <summary>
-        /// Gets or sets the AddStringOp.
-        /// </summary>
-        /// <value>The add string op.</value>
-        public AddStringOperation AddStringOp { get; set; }
+        private List<IRenameOperation> RenameOperations
+        {
+            get
+            {
+                if (this.renameOperations == null)
+                {
+                    this.renameOperations = new List<IRenameOperation>();
+                }
 
-        /// <summary>
-        /// Gets or sets the TrimCharactersOp.
-        /// </summary>
-        /// <value>The trim characters op.</value>
-        public TrimCharactersOperation TrimCharactersOp { get; set; }
+                return this.renameOperations;
+            }
+        }
 
-        /// <summary>
-        /// Gets or sets the EnumerateOp.
-        /// </summary>
-        /// <value>The enumerate op.</value>
-        public EnumerateOperation EnumerateOp { get; set; }
+        public void SetRenameOperation(IRenameOperation operation)
+        {
+            var operationList = new List<IRenameOperation>();
+            operationList.Add(operation);
+            this.SetRenameOperations(operationList);
+        }
+
+        public void SetRenameOperations(List<IRenameOperation> operations)
+        {
+            this.RenameOperations.Clear();
+            this.RenameOperations.AddRange(operations);
+        }
 
         /// <summary>
         /// Gets the string, renamed according to the BulkRenamer configuration.
@@ -78,25 +81,9 @@ namespace RedBlueGames.BulkRename
         {
             var modifiedName = originalName;
 
-            if (this.TrimCharactersOp != null)
+            foreach (var op in this.RenameOperations)
             {
-                modifiedName = this.TrimCharactersOp.Rename(modifiedName, count, includeDiff);
-            }
-
-            // Replace strings first so we don't replace the prefix.
-            if (this.ReplaceStringOp != null)
-            {
-                modifiedName = this.ReplaceStringOp.Rename(modifiedName, count, includeDiff);
-            }
-
-            if (this.AddStringOp != null)
-            {
-                modifiedName = this.AddStringOp.Rename(modifiedName, count, includeDiff);
-            }
-
-            if (this.EnumerateOp != null)
-            {
-                modifiedName = this.EnumerateOp.Rename(modifiedName, count, includeDiff);
+                modifiedName = op.Rename(modifiedName, count, includeDiff);
             }
 
             return modifiedName;

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
@@ -46,6 +46,10 @@ namespace RedBlueGames.BulkRename
             }
         }
 
+        /// <summary>
+        /// Sets the rename operation to use.
+        /// </summary>
+        /// <param name="operation">Operation to assign.</param>
         public void SetRenameOperation(IRenameOperation operation)
         {
             var operationList = new List<IRenameOperation>();
@@ -53,6 +57,10 @@ namespace RedBlueGames.BulkRename
             this.SetRenameOperations(operationList);
         }
 
+        /// <summary>
+        /// Sets the rename operations.
+        /// </summary>
+        /// <param name="operations">Operations to assign.</param>
         public void SetRenameOperations(List<IRenameOperation> operations)
         {
             this.RenameOperations.Clear();
@@ -60,7 +68,7 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Gets the string, renamed according to the BulkRenamer configuration.
+        /// Gets all strings renamed according to the BulkRenamer configuration.
         /// </summary>
         /// <returns>The renamed strings.</returns>
         /// <param name="includeDiff">If set to <c>true</c> outputs the name including diff with rich text tags.</param>

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
@@ -25,6 +25,7 @@ namespace RedBlueGames.BulkRename
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using UnityEditor;
     using UnityEngine;
 
@@ -36,11 +37,14 @@ namespace RedBlueGames.BulkRename
         private const string AssetsMenuPath = "Assets/Red Blue/Rename In Bulk";
         private const string GameObjectMenuPath = "GameObject/Red Blue/Rename In Bulk";
 
+        private Vector2 renameOperationsPanelScrollPosition;
         private Vector2 previewPanelScrollPosition;
         private List<UnityEngine.Object> objectsToRename;
 
+        private List<BaseRenameOperation> renameOperationsFactory;
+
         private BulkRenamer bulkRenamer;
-        private List<IRenameOperation> renameOperations;
+        private List<BaseRenameOperation> renameOperationsToApply;
 
         [MenuItem(AssetsMenuPath, false, 1011)]
         [MenuItem(GameObjectMenuPath, false, 49)]
@@ -96,29 +100,32 @@ namespace RedBlueGames.BulkRename
             EditorGUILayout.EndHorizontal();
         }
 
-        private static void DrawPreviewRow(Texture icon, string originalName, string diffedName, string newName)
+        private static void DrawPreviewRow(PreviewRowInfo info)
         {
+            // Draw the icon
             EditorGUILayout.BeginHorizontal(GUILayout.Height(18.0f));
             GUILayout.Space(8.0f);
-            if (icon != null)
+            if (info.Icon != null)
             {
                 GUIStyle boxStyle = GUIStyle.none;
-                GUILayout.Box(icon, boxStyle, GUILayout.Width(16.0f), GUILayout.Height(16.0f));
+                GUILayout.Box(info.Icon, boxStyle, GUILayout.Width(16.0f), GUILayout.Height(16.0f));
             }
 
-            // Calculate if names differ for use with styles
-            bool namesDiffer = newName != originalName;
-
             // Display diff
-            var diffStyle = namesDiffer ? EditorStyles.boldLabel : new GUIStyle(EditorStyles.label);
+            var diffStyle = info.NamesAreDifferent ? EditorStyles.boldLabel : new GUIStyle(EditorStyles.label);
             diffStyle.richText = true;
-            EditorGUILayout.LabelField(diffedName, diffStyle);
+            EditorGUILayout.LabelField(info.DiffName, diffStyle);
 
             // Display new name
-            var style = namesDiffer ? EditorStyles.boldLabel : new GUIStyle(EditorStyles.label);
-            EditorGUILayout.LabelField(newName, style);
+            var style = info.NamesAreDifferent ? EditorStyles.boldLabel : new GUIStyle(EditorStyles.label);
+            EditorGUILayout.LabelField(info.NewName, style);
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private static void DrawDivider()
+        {
+            GUILayout.Box(string.Empty, GUILayout.ExpandWidth(true), GUILayout.Height(2.0f));
         }
 
         private static Texture GetIconForObject(UnityEngine.Object unityObject)
@@ -146,15 +153,31 @@ namespace RedBlueGames.BulkRename
 
         private void OnEnable()
         {
+            this.minSize = new Vector2(600.0f, 300.0f);
+
             this.previewPanelScrollPosition = Vector2.zero;
 
             this.bulkRenamer = new BulkRenamer();
+            this.renameOperationsToApply = new List<BaseRenameOperation>();
+            this.renameOperationsToApply.Add(new ReplaceStringOperation());
 
-            this.renameOperations = new List<IRenameOperation>();
-            this.renameOperations.Add(new TrimCharactersOperation());
-            this.renameOperations.Add(new ReplaceStringOperation());
-            this.renameOperations.Add(new AddStringOperation());
-            this.renameOperations.Add(new EnumerateOperation());
+            // Cache all valid Rename Operations
+            this.renameOperationsFactory = new List<BaseRenameOperation>();
+            var assembly = Assembly.Load(new AssemblyName("Assembly-CSharp-Editor"));
+            var typesInAssembly = assembly.GetTypes();
+            foreach (var type in typesInAssembly)
+            {
+                if (type.IsSubclassOf(typeof(BaseRenameOperation)))
+                {
+                    var renameOp = (BaseRenameOperation)System.Activator.CreateInstance(type);
+                    this.renameOperationsFactory.Add(renameOp);
+                }
+            }
+
+            this.renameOperationsFactory.Sort((x, y) =>
+                {
+                    return x.MenuOrder.CompareTo(y.MenuOrder);
+                });
 
             Selection.selectionChanged += this.Repaint;
         }
@@ -200,35 +223,128 @@ namespace RedBlueGames.BulkRename
 
             EditorGUILayout.Space();
 
-            for (int i = 0; i < this.renameOperations.Count; ++i)
+            EditorGUILayout.BeginHorizontal();
+
+            this.renameOperationsPanelScrollPosition = 
+                EditorGUILayout.BeginScrollView(
+                this.renameOperationsPanelScrollPosition,
+                GUILayout.MinWidth(300.0f),
+                GUILayout.MaxWidth(500.0f));
+
+            for (int i = 0; i < this.renameOperationsToApply.Count; ++i)
             {
-                this.renameOperations[i] = this.renameOperations[i].DrawGUI();
+                this.renameOperationsToApply[i] = this.renameOperationsToApply[i].DrawGUI();
+                DrawDivider();
             }
 
-            // Reassign the changed values back to the bulk renamer
-            this.bulkRenamer.SetRenameOperations(this.renameOperations);
+            // Can't use these ops in Bulk Renamer without first converting them to the interface
+            var renameOpsAsInterfaces = new List<IRenameOperation>();
+            foreach (var renameOp in this.renameOperationsToApply)
+            {
+                renameOpsAsInterfaces.Add((IRenameOperation)renameOp);
+            }
 
-            if (GUILayout.Button("Rename"))
+            this.bulkRenamer.SetRenameOperations(renameOpsAsInterfaces);
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Add Operation", GUILayout.Width(150.0f)))
+            {
+                // Add enums to the menu
+                var menu = new GenericMenu();
+                for (int i = 0; i < this.renameOperationsFactory.Count; ++i)
+                {
+                    var renameOp = this.renameOperationsFactory[i];
+                    var content = new GUIContent(renameOp.MenuDisplayPath);
+                    menu.AddItem(content, false, this.OnAddRenameOperationConfirmed, renameOp);
+                }
+
+                menu.ShowAsContext();
+            }
+
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.EndScrollView();
+
+            GUILayout.Box(string.Empty, GUILayout.ExpandHeight(true), GUILayout.Width(3.0f));
+
+            EditorGUILayout.BeginVertical();
+
+            this.previewPanelScrollPosition = EditorGUILayout.BeginScrollView(this.previewPanelScrollPosition);
+
+            // Note that something about the way we draw the preview title, requires it to be included in the scroll view in order
+            // for the scroll to measure horiztonal size correctly.
+            DrawPreviewTitle();
+
+            var previewRowData = this.GetPreviewRowDataFromObjectsToRename();
+            for (int i = 0; i < previewRowData.Length; ++i)
+            {
+                DrawPreviewRow(previewRowData[i]);
+            }
+
+            EditorGUILayout.EndScrollView();
+
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.Space(30.0f);
+            if (GUILayout.Button("Rename", GUILayout.Height(24.0f)))
             {
                 this.RenameAssets();
                 this.Close();
             }
 
+            GUILayout.Space(30.0f);
+            EditorGUILayout.EndHorizontal();
+
             EditorGUILayout.Space();
-            GUILayout.Box(string.Empty, GUILayout.ExpandWidth(true), GUILayout.Height(1));
+        }
 
-            DrawPreviewTitle();
+        private void OnAddRenameOperationConfirmed(object operation)
+        {
+            var operationAsRenameOp = operation as BaseRenameOperation;
+            if (operationAsRenameOp == null)
+            {
+                throw new System.ArgumentException(
+                    "BulkRenamerWindow tried to add a new RenameOperation using a type that is not a subclass of BaseRenameOperation." +
+                    " Operation type: " +
+                    operation.GetType().ToString());
+            }
 
-            this.previewPanelScrollPosition = EditorGUILayout.BeginScrollView(this.previewPanelScrollPosition);
+            // Construct the Rename op
+            var renameOp = operationAsRenameOp.Clone();
+            this.renameOperationsToApply.Add(renameOp);
+
+            // Scroll to the bottom to focus the newly created operation.
+            this.renameOperationsPanelScrollPosition = new Vector2(0.0f, 10000000.0f);
+            this.Repaint();
+        }
+
+        private PreviewRowInfo[] GetPreviewRowDataFromObjectsToRename()
+        {
+            var previewRowInfos = new PreviewRowInfo[this.objectsToRename.Count];
             var selectedNames = this.GetNamesFromObjectsToRename();
             var namePreviews = this.bulkRenamer.GetRenamedStrings(false, selectedNames);
             var nameDiffs = this.bulkRenamer.GetRenamedStrings(true, selectedNames);
-            for (int i = 0; i < namePreviews.Length; ++i)
+
+            for (int i = 0; i < selectedNames.Length; ++i)
             {
-                DrawPreviewRow(GetIconForObject(this.objectsToRename[i]), selectedNames[i], nameDiffs[i], namePreviews[i]);
+                var info = new PreviewRowInfo();
+                info.OriginalName = selectedNames[i];
+                info.DiffName = nameDiffs[i];
+                info.NewName = namePreviews[i];
+                info.Icon = GetIconForObject(this.objectsToRename[i]);
+
+                previewRowInfos[i] = info;
             }
 
-            EditorGUILayout.EndScrollView();
+            return previewRowInfos;
         }
 
         private string[] GetNamesFromObjectsToRename()
@@ -290,6 +406,25 @@ namespace RedBlueGames.BulkRename
         {
             var pathToAsset = AssetDatabase.GetAssetPath(asset);
             AssetDatabase.RenameAsset(pathToAsset, newName);
+        }
+
+        private struct PreviewRowInfo
+        {
+            public Texture Icon { get; set; }
+
+            public string OriginalName { get; set; }
+
+            public string DiffName { get; set; }
+
+            public string NewName { get; set; }
+
+            public bool NamesAreDifferent
+            {
+                get
+                {
+                    return this.NewName != this.OriginalName;
+                }
+            }
         }
     }
 }

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
@@ -38,12 +38,9 @@ namespace RedBlueGames.BulkRename
 
         private Vector2 previewPanelScrollPosition;
         private List<UnityEngine.Object> objectsToRename;
-        private BulkRenamer bulkRenamer;
 
-        private TrimCharactersOperation trimCharactersOp;
-        private ReplaceStringOperation replacementStringOp;
-        private AddStringOperation addStringOp;
-        private EnumerateOperation enumerateOp;
+        private BulkRenamer bulkRenamer;
+        private List<IRenameOperation> renameOperations;
 
         [MenuItem(AssetsMenuPath, false, 1011)]
         [MenuItem(GameObjectMenuPath, false, 49)]
@@ -151,16 +148,13 @@ namespace RedBlueGames.BulkRename
         {
             this.previewPanelScrollPosition = Vector2.zero;
 
-            this.trimCharactersOp = new TrimCharactersOperation();
-            this.replacementStringOp = new ReplaceStringOperation();
-            this.addStringOp = new AddStringOperation();
-            this.enumerateOp = new EnumerateOperation();
             this.bulkRenamer = new BulkRenamer();
 
-            this.bulkRenamer.TrimCharactersOp = this.trimCharactersOp;
-            this.bulkRenamer.ReplaceStringOp = this.replacementStringOp;
-            this.bulkRenamer.AddStringOp = this.addStringOp;
-            this.bulkRenamer.EnumerateOp = this.enumerateOp;
+            this.renameOperations = new List<IRenameOperation>();
+            this.renameOperations.Add(new TrimCharactersOperation());
+            this.renameOperations.Add(new ReplaceStringOperation());
+            this.renameOperations.Add(new AddStringOperation());
+            this.renameOperations.Add(new EnumerateOperation());
 
             Selection.selectionChanged += this.Repaint;
         }
@@ -206,16 +200,13 @@ namespace RedBlueGames.BulkRename
 
             EditorGUILayout.Space();
 
-            this.replacementStringOp = (ReplaceStringOperation)this.replacementStringOp.DrawGUI();
-            this.addStringOp = (AddStringOperation)this.addStringOp.DrawGUI();
-            this.trimCharactersOp = (TrimCharactersOperation)this.trimCharactersOp.DrawGUI();
-            this.enumerateOp = (EnumerateOperation)this.enumerateOp.DrawGUI();
+            for (int i = 0; i < this.renameOperations.Count; ++i)
+            {
+                this.renameOperations[i] = this.renameOperations[i].DrawGUI();
+            }
 
-            // For now reassign the values for the ops
-            this.bulkRenamer.ReplaceStringOp = this.replacementStringOp;
-            this.bulkRenamer.AddStringOp = this.addStringOp;
-            this.bulkRenamer.TrimCharactersOp = this.trimCharactersOp;
-            this.bulkRenamer.EnumerateOp = this.enumerateOp;
+            // Reassign the changed values back to the bulk renamer
+            this.bulkRenamer.SetRenameOperations(this.renameOperations);
 
             if (GUILayout.Button("Rename"))
             {

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/AddStringOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/AddStringOperation.cs
@@ -55,6 +55,30 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
+        /// Gets the path that's displayed when this rename op is used in the Add Op menu.
+        /// </summary>
+        /// <value>The display path.</value>
+        public override string MenuDisplayPath
+        {
+            get
+            {
+                return "Add String";
+            }
+        }
+
+        /// <summary>
+        /// Gets the order in which this rename op is displayed in the Add Op menu (lower is higher in the list.)
+        /// </summary>
+        /// <value>The menu order.</value>
+        public override int MenuOrder
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the prefix to add.
         /// </summary>
         /// <value>The prefix to add..</value>
@@ -65,6 +89,16 @@ namespace RedBlueGames.BulkRename
         /// </summary>
         /// <value>The suffix to add.</value>
         public string Suffix { get; set; }
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public override BaseRenameOperation Clone()
+        {
+            var clone = new AddStringOperation(this);
+            return clone;
+        }
 
         /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
@@ -96,12 +130,14 @@ namespace RedBlueGames.BulkRename
         /// Operation with the modified data. This way we mirror how regular GUI calls work.
         /// </summary>
         /// <returns>A modified copy of the Operation.</returns>
-        public override IRenameOperation DrawGUI()
+        public override BaseRenameOperation DrawGUI()
         {   
             var clone = new AddStringOperation(this);
             EditorGUILayout.LabelField("Additions", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             clone.Prefix = EditorGUILayout.TextField("Prefix", this.Prefix);
             clone.Suffix = EditorGUILayout.TextField("Suffix", this.Suffix);
+            EditorGUI.indentLevel--;
             return clone;
         }
     }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
@@ -40,6 +40,18 @@ namespace RedBlueGames.BulkRename
         private const string EndColorTag = "</color>";
 
         /// <summary>
+        /// Gets the path that's displayed when this rename op is used in the Add Op menu.
+        /// </summary>
+        /// <value>The display path.</value>
+        public abstract string MenuDisplayPath { get; }
+
+        /// <summary>
+        /// Gets the order in which this rename op is displayed in the Add Op menu (lower is higher in the list.)
+        /// </summary>
+        /// <value>The menu order.</value>
+        public abstract int MenuOrder { get; }
+
+        /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
@@ -53,7 +65,13 @@ namespace RedBlueGames.BulkRename
         /// Operation with the modified data. This way we mirror how regular GUI calls work.
         /// </summary>
         /// <returns>A modified copy of the Operation.</returns>
-        public abstract IRenameOperation DrawGUI();
+        public abstract BaseRenameOperation DrawGUI();
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public abstract BaseRenameOperation Clone();
 
         /// <summary>
         /// Colors a string to represent an Added string (for a diff)

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/EnumerateOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/EnumerateOperation.cs
@@ -55,6 +55,30 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
+        /// Gets the path that's displayed when this rename op is used in the Add Op menu.
+        /// </summary>
+        /// <value>The display path.</value>
+        public override string MenuDisplayPath
+        {
+            get
+            {
+                return "Enumerate";
+            }
+        }
+
+        /// <summary>
+        /// Gets the order in which this rename op is displayed in the Add Op menu (lower is higher in the list.)
+        /// </summary>
+        /// <value>The menu order.</value>
+        public override int MenuOrder
+        {
+            get
+            {
+                return 4;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the starting count.
         /// </summary>
         /// <value>The starting count.</value>
@@ -65,6 +89,16 @@ namespace RedBlueGames.BulkRename
         /// </summary>
         /// <value>The count format.</value>
         public string CountFormat { get; set; }
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public override BaseRenameOperation Clone()
+        {
+            var clone = new EnumerateOperation(this);
+            return clone;
+        }
 
         /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
@@ -105,10 +139,11 @@ namespace RedBlueGames.BulkRename
         /// Operation with the modified data. This way we mirror how regular GUI calls work.
         /// </summary>
         /// <returns>A modified copy of the Operation.</returns>
-        public override IRenameOperation DrawGUI()
+        public override BaseRenameOperation DrawGUI()
         {   
             var clone = new EnumerateOperation(this);
             EditorGUILayout.LabelField("Enumerating", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             clone.CountFormat = EditorGUILayout.TextField("Count Format", this.CountFormat);
 
             try
@@ -125,6 +160,8 @@ namespace RedBlueGames.BulkRename
             }
 
             clone.StartingCount = EditorGUILayout.IntField("Count From", this.StartingCount);
+
+            EditorGUI.indentLevel--;
             return clone;
         }
     }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/IRenameOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/IRenameOperation.cs
@@ -36,12 +36,5 @@ namespace RedBlueGames.BulkRename
         /// <param name="includeDiff">If set to <c>true</c> output the string with diffed text.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
         string Rename(string input, int relativeCount, bool includeDiff);
-
-        /// <summary>
-        /// Draws the element as a GUI using EditorGUILayout calls. This should return a copy of the 
-        /// Operation with the modified data. This way we mirror how regular GUI calls work.
-        /// </summary>
-        /// <returns>A modified copy of the Operation.</returns>
-        IRenameOperation DrawGUI();
     }
 }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
@@ -57,6 +57,30 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
+        /// Gets the path that's displayed when this rename op is used in the Add Op menu.
+        /// </summary>
+        /// <value>The display path.</value>
+        public override string MenuDisplayPath
+        {
+            get
+            {
+                return "Replace String";
+            }
+        }
+
+        /// <summary>
+        /// Gets the order in which this rename op is displayed in the Add Op menu (lower is higher in the list.)
+        /// </summary>
+        /// <value>The menu order.</value>
+        public override int MenuOrder
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the search string, used to determine what text to replace.
         /// </summary>
         /// <value>The search string.</value>
@@ -73,6 +97,16 @@ namespace RedBlueGames.BulkRename
         /// </summary>
         /// <value>The replacement string.</value>
         public string ReplacementString { get; set; }
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public override BaseRenameOperation Clone()
+        {
+            var clone = new ReplaceStringOperation(this);
+            return clone;
+        }
 
         /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
@@ -118,13 +152,15 @@ namespace RedBlueGames.BulkRename
         /// Operation with the modified data. This way we mirror how regular GUI calls work.
         /// </summary>
         /// <returns>A modified copy of the Operation.</returns>
-        public override IRenameOperation DrawGUI()
+        public override BaseRenameOperation DrawGUI()
         {   
             var clone = new ReplaceStringOperation(this);
             EditorGUILayout.LabelField("Text Replacement", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             clone.SearchString = EditorGUILayout.TextField("Search for String", this.SearchString);
             clone.ReplacementString = EditorGUILayout.TextField("Replace with", this.ReplacementString);
             clone.SearchIsCaseSensitive = EditorGUILayout.Toggle("Case Sensitive", this.SearchIsCaseSensitive);
+            EditorGUI.indentLevel--;
             return clone;
         }
     }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/TrimCharactersOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/TrimCharactersOperation.cs
@@ -55,6 +55,30 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
+        /// Gets the path that's displayed when this rename op is used in the Add Op menu.
+        /// </summary>
+        /// <value>The display path.</value>
+        public override string MenuDisplayPath
+        {
+            get
+            {
+                return "Trim Characters";
+            }
+        }
+
+        /// <summary>
+        /// Gets the order in which this rename op is displayed in the Add Op menu (lower is higher in the list.)
+        /// </summary>
+        /// <value>The menu order.</value>
+        public override int MenuOrder
+        {
+            get
+            {
+                return 3;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the number of characters to delete from the front.
         /// </summary>
         /// <value>The number front delete chars.</value>
@@ -65,6 +89,16 @@ namespace RedBlueGames.BulkRename
         /// </summary>
         /// <value>The number back delete chars.</value>
         public int NumBackDeleteChars { get; set; }
+
+        /// <summary>
+        /// Clone this instance.
+        /// </summary>
+        /// <returns>A clone of this instance</returns>
+        public override BaseRenameOperation Clone()
+        {
+            var clone = new TrimCharactersOperation(this);
+            return clone;
+        }
 
         /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
@@ -120,16 +154,16 @@ namespace RedBlueGames.BulkRename
         /// Operation with the modified data. This way we mirror how regular GUI calls work.
         /// </summary>
         /// <returns>A modified copy of the Operation.</returns>
-        public override IRenameOperation DrawGUI()
+        public override BaseRenameOperation DrawGUI()
         {   
             var clone = new TrimCharactersOperation(this);
             EditorGUILayout.LabelField("Trimming", EditorStyles.boldLabel);
-            EditorGUILayout.BeginHorizontal();
+            EditorGUI.indentLevel++;
             clone.NumFrontDeleteChars = EditorGUILayout.IntField("Delete From Front", this.NumFrontDeleteChars);
             clone.NumFrontDeleteChars = Mathf.Max(0, clone.NumFrontDeleteChars);
             clone.NumBackDeleteChars = EditorGUILayout.IntField("Delete from Back", this.NumBackDeleteChars);
             clone.NumBackDeleteChars = Mathf.Max(0, clone.NumBackDeleteChars);
-            EditorGUILayout.EndHorizontal();
+            EditorGUI.indentLevel--;
             return clone;
         }
     }

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace RedBlueGames.BulkRename.Tests
 {
     using System.Collections;
+    using System.Collections.Generic;
     using UnityEngine;
     using NUnit.Framework;
 
@@ -14,7 +15,7 @@
             var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = string.Empty;
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
@@ -34,7 +35,7 @@
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Hero";
             replaceStringOp.ReplacementString = "A";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "CHAR_A_Spawn";
 
@@ -53,7 +54,7 @@
             var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "o";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "StlDdad";
 
@@ -72,7 +73,7 @@
             var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Heroine";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
@@ -92,7 +93,7 @@
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Hero";
             replaceStringOp.ReplacementString = "Link";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "Char_Link_Spawn";
 
@@ -113,7 +114,7 @@
             replaceStringOp.SearchIsCaseSensitive = false;
             replaceStringOp.SearchString = "ZelDa";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blahblah";
 
@@ -134,7 +135,7 @@
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.SearchString = "zelda";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "ZELDA";
 
@@ -155,7 +156,7 @@
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.SearchString = "ZeldA";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blah";
 
@@ -174,7 +175,7 @@
             var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Prefix = string.Empty;
-            bulkRenamer.AddStringOp = addStringOp;
+            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = name;
 
@@ -193,7 +194,7 @@
             var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Prefix = "Char_";
-            bulkRenamer.AddStringOp = addStringOp;
+            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = "Char_Hero_Spawn";
 
@@ -212,7 +213,7 @@
             var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Suffix = string.Empty;
-            bulkRenamer.AddStringOp = addStringOp;
+            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = name;
 
@@ -231,7 +232,7 @@
             var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Suffix = "_Spawn";
-            bulkRenamer.AddStringOp = addStringOp;
+            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = "Char_Hero_Spawn";
 
@@ -251,7 +252,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 0;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = name;
 
@@ -271,7 +272,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 1;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "har_Hero";
 
@@ -291,7 +292,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 0;
             trimCharactersOp.NumBackDeleteChars = 1;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "Char_Her";
 
@@ -311,7 +312,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 1;
             trimCharactersOp.NumBackDeleteChars = 1;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "har_Her";
 
@@ -331,7 +332,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = name.Length + 2;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = string.Empty;
 
@@ -351,7 +352,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = name.Length;
             trimCharactersOp.NumBackDeleteChars = name.Length;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = string.Empty;
 
@@ -371,7 +372,7 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = -1;
             trimCharactersOp.NumBackDeleteChars = -10;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
+            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = name;
 
@@ -390,7 +391,7 @@
             var bulkRenamer = new BulkRenamer();
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = string.Empty;
-            bulkRenamer.EnumerateOp = enumerateOp;
+            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expected = name;
 
@@ -410,7 +411,7 @@
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = 0;
-            bulkRenamer.EnumerateOp = enumerateOp;
+            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expected = "Char_Hero0";
 
@@ -437,7 +438,7 @@
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = 1;
-            bulkRenamer.EnumerateOp = enumerateOp;
+            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expectedNames = new string[]
             {
@@ -472,7 +473,7 @@
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = -1;
-            bulkRenamer.EnumerateOp = enumerateOp;
+            bulkRenamer.SetRenameOperation(enumerateOp);
             var expected = "Char_Hero-1";
 
             // Act
@@ -491,7 +492,7 @@
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "s";
             enumerateOp.StartingCount = 100;
-            bulkRenamer.EnumerateOp = enumerateOp;
+            bulkRenamer.SetRenameOperation(enumerateOp);
             var expected = "Char_Hero";
 
             // Act
@@ -511,22 +512,25 @@
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 1;
             trimCharactersOp.NumBackDeleteChars = 5;
-            bulkRenamer.TrimCharactersOp = trimCharactersOp;
 
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "r_H";
             replaceStringOp.ReplacementString = "t_Z";
-            bulkRenamer.ReplaceStringOp = replaceStringOp;
 
             var addStringOp = new AddStringOperation();
             addStringOp.Prefix = "a_";
             addStringOp.Suffix = "AA";
-            bulkRenamer.AddStringOp = addStringOp;
 
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "D4";
             enumerateOp.StartingCount = 100;
-            bulkRenamer.EnumerateOp = enumerateOp;
+
+            var listOfOperations = new List<IRenameOperation>();
+            listOfOperations.Add(trimCharactersOp);
+            listOfOperations.Add(replaceStringOp);
+            listOfOperations.Add(addStringOp);
+            listOfOperations.Add(enumerateOp);
+            bulkRenamer.SetRenameOperations(listOfOperations);
 
             var expected = "a_hat_ZeroAA0100";
 

--- a/Assets/RedBlueGames/BulkRename/Tests/GameObjects/RenameGameObjects.unity
+++ b/Assets/RedBlueGames/BulkRename/Tests/GameObjects/RenameGameObjects.unity
@@ -147,6 +147,116 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &230501679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 230501684}
+  - component: {fileID: 230501683}
+  - component: {fileID: 230501682}
+  - component: {fileID: 230501681}
+  - component: {fileID: 230501680}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!111 &230501680
+Animation:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230501679}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 0}
+  m_Animations: []
+  m_WrapMode: 0
+  m_PlayAutomatically: 1
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!212 &230501681
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230501679}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+--- !u!68 &230501682
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230501679}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Points:
+  - {x: -0.5, y: 0}
+  - {x: 0.5, y: 0}
+--- !u!61 &230501683
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230501679}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+--- !u!4 &230501684
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230501679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &312676503
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Allow users to add any number of rename operations
    
    This adds a button that lets users choose a rename operation from a
    dropdown. Doing this simplifies the UI and lets users choose the order
    in which ops are applied.
    
    Fixes Issue #39
    Impacts Issue #21 which now simply requires reordering / deleting
    rename operations.
    
    For record keeping, here is the order I committed changed:
    - Allow adding an arbitrary number of Rename Operations
    - Allow RenameOps to specify their Display Name
    - Add sorting to the Rename Ops in the context menu
    - Revamp Window UI to use two columns
    - Comply with StyleCop
    - Fix scrolling on preview pane
    - Cleanup function that took too many parameters