### PR TITLE
Add support for Regex to Replace String op

### DIFF
--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
@@ -237,7 +237,7 @@ namespace RedBlueGames.BulkRename
                 DrawDivider();
             }
 
-            // Can't use these ops in Bulk Rename
+            // BulkRenamer expects the list typed as IRenameOperations
             var renameOpsAsInterfaces = new List<IRenameOperation>();
             foreach (var renameOp in this.renameOperationsToApply)
             {

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
@@ -237,7 +237,7 @@ namespace RedBlueGames.BulkRename
                 DrawDivider();
             }
 
-            // Can't use these ops in Bulk Renamer without first converting them to the interface
+            // Can't use these ops in Bulk Rename
             var renameOpsAsInterfaces = new List<IRenameOperation>();
             foreach (var renameOp in this.renameOperationsToApply)
             {
@@ -294,11 +294,15 @@ namespace RedBlueGames.BulkRename
 
             EditorGUILayout.BeginHorizontal();
             GUILayout.Space(30.0f);
+
+            EditorGUI.BeginDisabledGroup(this.RenameOperatationsHaveErrors());
             if (GUILayout.Button("Rename", GUILayout.Height(24.0f)))
             {
                 this.RenameAssets();
                 this.Close();
             }
+
+            EditorGUI.EndDisabledGroup();
 
             GUILayout.Space(30.0f);
             EditorGUILayout.EndHorizontal();
@@ -406,6 +410,19 @@ namespace RedBlueGames.BulkRename
         {
             var pathToAsset = AssetDatabase.GetAssetPath(asset);
             AssetDatabase.RenameAsset(pathToAsset, newName);
+        }
+
+        private bool RenameOperatationsHaveErrors()
+        {
+            foreach (var renameOp in this.renameOperationsToApply)
+            {
+                if (renameOp.HasErrors)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private struct PreviewRowInfo

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
@@ -52,6 +52,18 @@ namespace RedBlueGames.BulkRename
         public abstract int MenuOrder { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this instance has errors that prevent it from Renaming.
+        /// </summary>
+        /// <value><c>true</c> if this instance has errors; otherwise, <c>false</c>.</value>
+        public virtual bool HasErrors
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
         /// </summary>
         /// <param name="input">Input String to rename.</param>

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
@@ -168,6 +168,216 @@
         }
 
         [Test]
+        public void SearchRegex_Empty_DoesNothing()
+        {
+            // Arrange
+            var name = "ThisIsAName";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = string.Empty;
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_OneMatch_IsReplaced()
+        {
+            // Arrange
+            var name = "CHAR_Hero_Spawn";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "Hero";
+            replaceStringOp.RegexReplacementString = "A";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "CHAR_A_Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_MultipleMatches_AllAreReplaced()
+        {
+            // Arrange
+            var name = "StoolDoodad";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "o";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "StlDdad";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_PartialMatches_AreNotReplaced()
+        {
+            // Arrange
+            var name = "Char_Hero_Spawn";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "Heroine";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = name;
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_Replacement_SubstitutesForSearchString()
+        {
+            // Arrange
+            var name = "Char_Hero_Spawn";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "Hero";
+            replaceStringOp.RegexReplacementString = "Link";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "Char_Link_Spawn";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_DoesNotMatchCase_Replaces()
+        {
+            // Arrange
+            var objectName = "ZELDAzelda";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.SearchIsCaseSensitive = false;
+            replaceStringOp.RegexSearchString = "ZelDa";
+            replaceStringOp.RegexReplacementString = "blah";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "blahblah";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegexCaseSensitive_DoesNotMatchCase_DoesNotReplace()
+        {
+            // Arrange
+            var objectName = "ZELDA";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.SearchIsCaseSensitive = true;
+            replaceStringOp.RegexSearchString = "zelda";
+            replaceStringOp.RegexReplacementString = "blah";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "ZELDA";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegexCaseSensitive_MatchesCase_Replaces()
+        {
+            // Arrange
+            var objectName = "ZeldA";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.SearchIsCaseSensitive = true;
+            replaceStringOp.RegexSearchString = "ZeldA";
+            replaceStringOp.RegexReplacementString = "blah";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "blah";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_SpecialCharactersInSearch_Replaces()
+        {
+            // Arrange
+            var objectName = "Char_Hero_Woot";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "[a-zA-Z]*_";
+            replaceStringOp.RegexReplacementString = "Yep";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "YepYepWoot";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void SearchRegex_EscapeCharactersInSearch_Replaces()
+        {
+            // Arrange
+            var objectName = "Char.Hero.Woot";
+            var bulkRenamer = new BulkRenamer();
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.UseRegex = true;
+            replaceStringOp.RegexSearchString = "\\.";
+            replaceStringOp.RegexReplacementString = "_";
+            bulkRenamer.SetRenameOperation(replaceStringOp);
+
+            var expected = "Char_Hero_Woot";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void AddPrefix_Empty_DoesNothing()
         {
             // Arrange


### PR DESCRIPTION
This adds a checkbox to use Regular expressions for the search and
replacement fields. It gracefully handles Regex expression errors.
Complies with StyleCop.

Resolves Issue #9