### PR TITLE
Reworks Diffing to only Diff the Final String and Original String

### DIFF
--- a/Assets/Editor/RBPackageExporter.cs
+++ b/Assets/Editor/RBPackageExporter.cs
@@ -138,9 +138,10 @@ public class RBPackageExporter : UnityEditor.EditorWindow
             }
         }
 
-        bool atLeastOnePackageSelected = selectedAssets.Count > 0;
+        bool atLeastOnePackageSelected = this.selectedAssets.Count > 0;
 
         EditorGUILayout.Separator();
+        EditorGUILayout.LabelField("Additional Options:", EditorStyles.boldLabel);
         this.includeTestFiles = EditorGUILayout.Toggle("Include Test Files", this.includeTestFiles);
         this.runUnitTests = EditorGUILayout.Toggle("Run Unit Tests", this.runUnitTests);
 
@@ -170,9 +171,9 @@ public class RBPackageExporter : UnityEditor.EditorWindow
     private void RunTests()
     {
         this.unitTestRunnerCallback = new TestRunnerCallback();
-        unitTestRunnerCallback.TestsSucceeded.AddListener(this.HandleTestsSucceeded);
-        unitTestRunnerCallback.TestsFailed.AddListener(this.HandleTestsFailed);
-        UnityEditor.EditorTests.Batch.RunTests(unitTestRunnerCallback);
+        this.unitTestRunnerCallback.TestsSucceeded.AddListener(this.HandleTestsSucceeded);
+        this.unitTestRunnerCallback.TestsFailed.AddListener(this.HandleTestsFailed);
+        UnityEditor.EditorTests.Batch.RunTests(this.unitTestRunnerCallback);
     }
 
     private void HandleTestsSucceeded()
@@ -184,10 +185,11 @@ public class RBPackageExporter : UnityEditor.EditorWindow
     private void HandleTestsFailed()
     {
         this.unitTestRunnerCallback = null;
-        UnityEditor.EditorUtility.DisplayDialog(
-            "Export Error", "Could not export packages because the Unit tests failed. " +
-            "You must fix the tests before exporting a project.",
-            "OK");
+        string dialogTitle = "Export Error";
+        string exportErrorMsg = "Could not export packages because the Unit tests failed. " +
+            "You must fix the tests before exporting a project.";
+        string confirmButtonText = "OK";
+        UnityEditor.EditorUtility.DisplayDialog(dialogTitle, exportErrorMsg, confirmButtonText);
     }
 
     private void ExportPackages(List<RBAsset> packages, bool includeTests)
@@ -266,15 +268,42 @@ public class RBPackageExporter : UnityEditor.EditorWindow
 
     private class TestRunnerCallback : UnityEditor.EditorTests.ITestRunnerCallback
     {
-        public UnityEngine.Events.UnityEvent TestsFailed;
-        public UnityEngine.Events.UnityEvent TestsSucceeded;
-
-        public bool IsFailure { get; private set; }
+        private UnityEngine.Events.UnityEvent testsFailed;
+        private UnityEngine.Events.UnityEvent testsSucceeded;
 
         public TestRunnerCallback()
         {
-            this.TestsSucceeded = new UnityEngine.Events.UnityEvent();
-            this.TestsFailed = new UnityEngine.Events.UnityEvent();
+            this.testsSucceeded = new UnityEngine.Events.UnityEvent();
+            this.testsFailed = new UnityEngine.Events.UnityEvent();
+        }
+
+        public bool IsFailure
+        {
+            get;
+
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the event callback for when Unit Tests fail.
+        /// </summary>
+        public UnityEngine.Events.UnityEvent TestsFailed
+        {
+            get
+            {
+                return this.testsFailed;
+            }
+        }
+
+        /// <summary>
+        /// Gets the event callback for when unity tests succeed.
+        /// </summary>
+        public UnityEngine.Events.UnityEvent TestsSucceeded
+        {
+            get
+            {
+                return this.testsSucceeded;
+            }
         }
 
         public void TestStarted(string testName)
@@ -313,7 +342,6 @@ public class RBPackageExporter : UnityEditor.EditorWindow
 
         public void RunFinishedException(System.Exception exception)
         {
-            
         }
     }
 }

--- a/Assets/Editor/RBPackageExporter.cs.meta
+++ b/Assets/Editor/RBPackageExporter.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: 83d87573060fb44fba118749ae2724c5
-timeCreated: 1480009765
-licenseType: Free
+guid: 78e8304f279b4413a9d633fd0fd115a6
+timeCreated: 1437422134
+licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs
@@ -1,16 +1,18 @@
-﻿using System.Collections.Generic;
-using RedBlueGames.BulkRename.Dependencies.DiffMatchPatch;
-
-namespace RedBlueGames.BulkRename
+﻿namespace RedBlueGames.BulkRename
 {
+    using System.Collections.Generic;
+    using RedBlueGames.BulkRename.Dependencies.DiffMatchPatch;
+
+    /// <summary>
+    /// Bulk rename preview contains the data for the results of a BulkRename operation.
+    /// </summary>
     public class BulkRenamePreview
     {
-        public string OriginalName { get; private set; }
-
-        public string NewName { get; private set; }
-
-        private List<Diff> Diffs { get; set; }
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedBlueGames.BulkRename.BulkRenamePreview"/> class.
+        /// </summary>
+        /// <param name="originalName">Original name.</param>
+        /// <param name="newName">New name.</param>
         public BulkRenamePreview(string originalName, string newName)
         {
             this.OriginalName = originalName;
@@ -20,17 +22,37 @@ namespace RedBlueGames.BulkRename
             this.Diffs = differ.diff_main(originalName, newName, false);
         }
 
+        /// <summary>
+        /// Gets the original name, before any rename operation.
+        /// </summary>
+        /// <value>The original name.</value>
+        public string OriginalName { get; private set; }
+
+        /// <summary>
+        /// Gets the new name, after the rename operations.
+        /// </summary>
+        /// <value>The new name.</value>
+        public string NewName { get; private set; }
+
+        private List<Diff> Diffs { get; set; }
+
+        /// <summary>
+        /// Gets the diff of the two names, formatted with color tags.
+        /// </summary>
+        /// <returns>The diff as a formatted string.</returns>
+        /// <param name="colorTagForAdds">Color tag for adds.</param>
+        /// <param name="colorTagForDeletes">Color tag for deletes.</param>
         public string GetDiffAsFormattedString(string colorTagForAdds, string colorTagForDeletes)
         {
             var diffedName = string.Empty;
             foreach (var diffResult in this.Diffs)
             {
                 var segment = string.Empty;
-                if (diffResult.operation == Operation.DELETE)
+                if (diffResult.operation == Operation.INSERT)
                 {
                     segment = string.Concat(colorTagForAdds, diffResult.text, "</color>");
                 }
-                else if (diffResult.operation == Operation.INSERT)
+                else if (diffResult.operation == Operation.DELETE)
                 {
                     segment = string.Concat(colorTagForDeletes, diffResult.text, "</color>");
                 }

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using RedBlueGames.BulkRename.Dependencies.DiffMatchPatch;
+
+namespace RedBlueGames.BulkRename
+{
+    public class BulkRenamePreview
+    {
+        public string OriginalName { get; private set; }
+
+        public string NewName { get; private set; }
+
+        private List<Diff> Diffs { get; set; }
+
+        public BulkRenamePreview(string originalName, string newName)
+        {
+            this.OriginalName = originalName;
+            this.NewName = newName;
+
+            var differ = new diff_match_patch();
+            this.Diffs = differ.diff_main(originalName, newName, false);
+        }
+
+        public string GetDiffAsFormattedString(string colorTagForAdds, string colorTagForDeletes)
+        {
+            var diffedName = string.Empty;
+            foreach (var diffResult in this.Diffs)
+            {
+                var segment = string.Empty;
+                if (diffResult.operation == Operation.DELETE)
+                {
+                    segment = string.Concat(colorTagForAdds, diffResult.text, "</color>");
+                }
+                else if (diffResult.operation == Operation.INSERT)
+                {
+                    segment = string.Concat(colorTagForDeletes, diffResult.text, "</color>");
+                }
+                else
+                {
+                    segment = diffResult.text;
+                }
+
+                diffedName += segment;
+            }
+
+            return diffedName;
+        }
+    }
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamePreview.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 53dff1e9697874fe7a26cd633f106c6d
+timeCreated: 1497580348
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamer.cs
@@ -68,30 +68,30 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Gets all strings renamed according to the BulkRenamer configuration.
+        /// Gets previews for the rename operations to be performed on the supplied strings.
         /// </summary>
-        /// <returns>The renamed strings.</returns>
-        /// <param name="includeDiff">If set to <c>true</c> outputs the name including diff with rich text tags.</param>
+        /// <returns>The RenamePreviews.</returns>
         /// <param name="originalNames">Original names to rename.</param>
-        public string[] GetRenamedStrings(bool includeDiff, params string[] originalNames)
+        public List<BulkRenamePreview> GetRenamePreviews(params string[] originalNames)
         {
-            var renamedStrings = new string[originalNames.Length];
+            var previews = new List<BulkRenamePreview>(originalNames.Length);
 
             for (int i = 0; i < originalNames.Length; ++i)
             {
-                renamedStrings[i] = this.GetRenamedString(originalNames[i], i, includeDiff);
+                var renamedString = this.GetRenamedString(originalNames[i], i);
+                previews.Add(new BulkRenamePreview(originalNames[i], renamedString));
             }
 
-            return renamedStrings;
+            return previews;
         }
 
-        private string GetRenamedString(string originalName, int count, bool includeDiff)
+        private string GetRenamedString(string originalName, int count)
         {
             var modifiedName = originalName;
 
             foreach (var op in this.RenameOperations)
             {
-                modifiedName = op.Rename(modifiedName, count, includeDiff);
+                modifiedName = op.Rename(modifiedName, count);
             }
 
             return modifiedName;

--- a/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/BulkRenamerWindow.cs
@@ -37,6 +37,9 @@ namespace RedBlueGames.BulkRename
         private const string AssetsMenuPath = "Assets/Red Blue/Rename In Bulk";
         private const string GameObjectMenuPath = "GameObject/Red Blue/Rename In Bulk";
 
+        private const string AddedTextColorTag = "<color=green>";
+        private const string DeletedTextColorTag = "<color=red>";
+
         private Vector2 renameOperationsPanelScrollPosition;
         private Vector2 previewPanelScrollPosition;
         private List<UnityEngine.Object> objectsToRename;
@@ -394,15 +397,15 @@ namespace RedBlueGames.BulkRename
         {
             var previewRowInfos = new PreviewRowInfo[this.objectsToRename.Count];
             var selectedNames = this.GetNamesFromObjectsToRename();
-            var namePreviews = this.bulkRenamer.GetRenamedStrings(false, selectedNames);
-            var nameDiffs = this.bulkRenamer.GetRenamedStrings(true, selectedNames);
+            var namePreviews = this.bulkRenamer.GetRenamePreviews(selectedNames);
 
-            for (int i = 0; i < selectedNames.Length; ++i)
+            for (int i = 0; i < namePreviews.Count; ++i)
             {
                 var info = new PreviewRowInfo();
-                info.OriginalName = selectedNames[i];
-                info.DiffName = nameDiffs[i];
-                info.NewName = namePreviews[i];
+                var namePreview = namePreviews[i];
+                info.OriginalName = namePreview.OriginalName;
+                info.DiffName = namePreview.GetDiffAsFormattedString(AddedTextColorTag, DeletedTextColorTag);
+                info.NewName = namePreview.NewName;
                 info.Icon = GetIconForObject(this.objectsToRename[i]);
 
                 previewRowInfos[i] = info;
@@ -429,21 +432,21 @@ namespace RedBlueGames.BulkRename
             Undo.RecordObjects(this.objectsToRename.ToArray(), "Bulk Rename");
 
             var names = this.GetNamesFromObjectsToRename();
-            var newNames = this.bulkRenamer.GetRenamedStrings(false, names);
+            var newNames = this.bulkRenamer.GetRenamePreviews(names);
 
-            for (int i = 0; i < newNames.Length; ++i)
+            for (int i = 0; i < newNames.Count; ++i)
             {
                 var infoString = string.Format(
                                      "Renaming asset {0} of {1}",
                                      i,
-                                     newNames.Length);
+                                     newNames.Count);
 
                 EditorUtility.DisplayProgressBar(
                     "Renaming Assets...",
                     infoString,
-                    i / (float)newNames.Length);
+                    i / (float)newNames.Count);
 
-                this.RenameObject(this.objectsToRename[i], newNames[i]);
+                this.RenameObject(this.objectsToRename[i], newNames[i].NewName);
             }
 
             EditorUtility.ClearProgressBar();

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8b21f9cc1211245539f4f1864d0cc3e5
+folderAsset: yes
+timeCreated: 1497582851
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/COPYING
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/COPYING
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/COPYING.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/COPYING.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94e4e710e67f743bbbd08ade5d0066b4
+timeCreated: 1497582889
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatch.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatch.cs
@@ -1,0 +1,2303 @@
+﻿/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: fraser@google.com (Neil Fraser)
+ * Author: anteru@developer.shelter13.net (Matthaeus G. Chajdas)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Diff Match and Patch
+ * http://code.google.com/p/google-diff-match-patch/
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using RedBlueGames.BulkRename.Dependencies;
+
+namespace RedBlueGames.BulkRename.Dependencies.DiffMatchPatch {
+  internal static class CompatibilityExtensions {
+    // JScript splice function
+    public static List<T> Splice<T>(this List<T> input, int start, int count,
+        params T[] objects) {
+      List<T> deletedRange = input.GetRange(start, count);
+      input.RemoveRange(start, count);
+      input.InsertRange(start, objects);
+
+      return deletedRange;
+    }
+
+    // Java substring function
+    public static string JavaSubstring(this string s, int begin, int end) {
+      return s.Substring(begin, end - begin);
+    }
+  }
+
+  /**-
+   * The data structure representing a diff is a List of Diff objects:
+   * {Diff(Operation.DELETE, "Hello"), Diff(Operation.INSERT, "Goodbye"),
+   *  Diff(Operation.EQUAL, " world.")}
+   * which means: delete "Hello", add "Goodbye" and keep " world."
+   */
+  public enum Operation {
+    DELETE, INSERT, EQUAL
+  }
+
+
+  /**
+   * Class representing one diff operation.
+   */
+  public class Diff {
+    public Operation operation;
+    // One of: INSERT, DELETE or EQUAL.
+    public string text;
+    // The text associated with this diff operation.
+
+    /**
+     * Constructor.  Initializes the diff with the provided values.
+     * @param operation One of INSERT, DELETE or EQUAL.
+     * @param text The text being applied.
+     */
+    public Diff(Operation operation, string text) {
+      // Construct a diff with the specified operation and text.
+      this.operation = operation;
+      this.text = text;
+    }
+
+    /**
+     * Display a human-readable version of this Diff.
+     * @return text version.
+     */
+    public override string ToString() {
+      string prettyText = this.text.Replace('\n', '\u00b6');
+      return "Diff(" + this.operation + ",\"" + prettyText + "\")";
+    }
+
+    /**
+     * Is this Diff equivalent to another Diff?
+     * @param d Another Diff to compare against.
+     * @return true or false.
+     */
+    public override bool Equals(Object obj) {
+      // If parameter is null return false.
+      if (obj == null) {
+        return false;
+      }
+
+      // If parameter cannot be cast to Diff return false.
+      Diff p = obj as Diff;
+      if ((System.Object)p == null) {
+        return false;
+      }
+
+      // Return true if the fields match.
+      return p.operation == this.operation && p.text == this.text;
+    }
+
+    public bool Equals(Diff obj) {
+      // If parameter is null return false.
+      if (obj == null) {
+        return false;
+      }
+
+      // Return true if the fields match.
+      return obj.operation == this.operation && obj.text == this.text;
+    }
+
+    public override int GetHashCode() {
+      return text.GetHashCode() ^ operation.GetHashCode();
+    }
+  }
+
+
+  /**
+   * Class representing one patch operation.
+   */
+  public class Patch {
+    public List<Diff> diffs = new List<Diff>();
+    public int start1;
+    public int start2;
+    public int length1;
+    public int length2;
+
+    /**
+     * Emmulate GNU diff's format.
+     * Header: @@ -382,8 +481,9 @@
+     * Indicies are printed as 1-based, not 0-based.
+     * @return The GNU diff string.
+     */
+    public override string ToString() {
+      string coords1, coords2;
+      if (this.length1 == 0) {
+        coords1 = this.start1 + ",0";
+      } else if (this.length1 == 1) {
+        coords1 = Convert.ToString(this.start1 + 1);
+      } else {
+        coords1 = (this.start1 + 1) + "," + this.length1;
+      }
+      if (this.length2 == 0) {
+        coords2 = this.start2 + ",0";
+      } else if (this.length2 == 1) {
+        coords2 = Convert.ToString(this.start2 + 1);
+      } else {
+        coords2 = (this.start2 + 1) + "," + this.length2;
+      }
+      StringBuilder text = new StringBuilder();
+      text.Append("@@ -").Append(coords1).Append(" +").Append(coords2)
+          .Append(" @@\n");
+      // Escape the body of the patch with %xx notation.
+      foreach (Diff aDiff in this.diffs) {
+        switch (aDiff.operation) {
+          case Operation.INSERT:
+            text.Append('+');
+            break;
+          case Operation.DELETE:
+            text.Append('-');
+            break;
+          case Operation.EQUAL:
+            text.Append(' ');
+            break;
+        }
+
+        text.Append(RestSharp.Contrib.HttpUtility.UrlEncode(aDiff.text,
+            new UTF8Encoding()).Replace('+', ' ')).Append("\n");
+      }
+
+      return diff_match_patch.unescapeForEncodeUriCompatability(
+          text.ToString());
+    }
+  }
+
+
+  /**
+   * Class containing the diff, match and patch methods.
+   * Also Contains the behaviour settings.
+   */
+  public class diff_match_patch {
+    // Defaults.
+    // Set these on your diff_match_patch instance to override the defaults.
+
+    // Number of seconds to map a diff before giving up (0 for infinity).
+    public float Diff_Timeout = 1.0f;
+    // Cost of an empty edit operation in terms of edit characters.
+    public short Diff_EditCost = 4;
+    // At what point is no match declared (0.0 = perfection, 1.0 = very loose).
+    public float Match_Threshold = 0.5f;
+    // How far to search for a match (0 = exact location, 1000+ = broad match).
+    // A match this many characters away from the expected location will add
+    // 1.0 to the score (0.0 is a perfect match).
+    public int Match_Distance = 1000;
+    // When deleting a large block of text (over ~64 characters), how close
+    // do the contents have to be to match the expected contents. (0.0 =
+    // perfection, 1.0 = very loose).  Note that Match_Threshold controls
+    // how closely the end points of a delete need to match.
+    public float Patch_DeleteThreshold = 0.5f;
+    // Chunk size for context length.
+    public short Patch_Margin = 4;
+
+    // The number of bits in an int.
+    private short Match_MaxBits = 32;
+
+
+    //  DIFF FUNCTIONS
+
+
+    /**
+     * Find the differences between two texts.
+     * Run a faster, slightly less optimal diff.
+     * This method allows the 'checklines' of diff_main() to be optional.
+     * Most of the time checklines is wanted, so default to true.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @return List of Diff objects.
+     */
+    public List<Diff> diff_main(string text1, string text2) {
+      return diff_main(text1, text2, true);
+    }
+
+    /**
+     * Find the differences between two texts.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param checklines Speedup flag.  If false, then don't run a
+     *     line-level diff first to identify the changed areas.
+     *     If true, then run a faster slightly less optimal diff.
+     * @return List of Diff objects.
+     */
+    public List<Diff> diff_main(string text1, string text2, bool checklines) {
+      // Set a deadline by which time the diff must be complete.
+      DateTime deadline;
+      if (this.Diff_Timeout <= 0) {
+        deadline = DateTime.MaxValue;
+      } else {
+        deadline = DateTime.Now +
+            new TimeSpan(((long)(Diff_Timeout * 1000)) * 10000);
+      }
+      return diff_main(text1, text2, checklines, deadline);
+    }
+
+    /**
+     * Find the differences between two texts.  Simplifies the problem by
+     * stripping any common prefix or suffix off the texts before diffing.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param checklines Speedup flag.  If false, then don't run a
+     *     line-level diff first to identify the changed areas.
+     *     If true, then run a faster slightly less optimal diff.
+     * @param deadline Time when the diff should be complete by.  Used
+     *     internally for recursive calls.  Users should set DiffTimeout
+     *     instead.
+     * @return List of Diff objects.
+     */
+    private List<Diff> diff_main(string text1, string text2, bool checklines,
+        DateTime deadline) {
+      // Check for null inputs not needed since null can't be passed in C#.
+
+      // Check for equality (speedup).
+      List<Diff> diffs;
+      if (text1 == text2) {
+        diffs = new List<Diff>();
+        if (text1.Length != 0) {
+          diffs.Add(new Diff(Operation.EQUAL, text1));
+        }
+        return diffs;
+      }
+
+      // Trim off common prefix (speedup).
+      int commonlength = diff_commonPrefix(text1, text2);
+      string commonprefix = text1.Substring(0, commonlength);
+      text1 = text1.Substring(commonlength);
+      text2 = text2.Substring(commonlength);
+
+      // Trim off common suffix (speedup).
+      commonlength = diff_commonSuffix(text1, text2);
+      string commonsuffix = text1.Substring(text1.Length - commonlength);
+      text1 = text1.Substring(0, text1.Length - commonlength);
+      text2 = text2.Substring(0, text2.Length - commonlength);
+
+      // Compute the diff on the middle block.
+      diffs = diff_compute(text1, text2, checklines, deadline);
+
+      // Restore the prefix and suffix.
+      if (commonprefix.Length != 0) {
+        diffs.Insert(0, (new Diff(Operation.EQUAL, commonprefix)));
+      }
+      if (commonsuffix.Length != 0) {
+        diffs.Add(new Diff(Operation.EQUAL, commonsuffix));
+      }
+
+      diff_cleanupMerge(diffs);
+      return diffs;
+    }
+
+    /**
+     * Find the differences between two texts.  Assumes that the texts do not
+     * have any common prefix or suffix.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param checklines Speedup flag.  If false, then don't run a
+     *     line-level diff first to identify the changed areas.
+     *     If true, then run a faster slightly less optimal diff.
+     * @param deadline Time when the diff should be complete by.
+     * @return List of Diff objects.
+     */
+    private List<Diff> diff_compute(string text1, string text2,
+                                    bool checklines, DateTime deadline) {
+      List<Diff> diffs = new List<Diff>();
+
+      if (text1.Length == 0) {
+        // Just add some text (speedup).
+        diffs.Add(new Diff(Operation.INSERT, text2));
+        return diffs;
+      }
+
+      if (text2.Length == 0) {
+        // Just delete some text (speedup).
+        diffs.Add(new Diff(Operation.DELETE, text1));
+        return diffs;
+      }
+
+      string longtext = text1.Length > text2.Length ? text1 : text2;
+      string shorttext = text1.Length > text2.Length ? text2 : text1;
+      int i = longtext.IndexOf(shorttext, StringComparison.Ordinal);
+      if (i != -1) {
+        // Shorter text is inside the longer text (speedup).
+        Operation op = (text1.Length > text2.Length) ?
+            Operation.DELETE : Operation.INSERT;
+        diffs.Add(new Diff(op, longtext.Substring(0, i)));
+        diffs.Add(new Diff(Operation.EQUAL, shorttext));
+        diffs.Add(new Diff(op, longtext.Substring(i + shorttext.Length)));
+        return diffs;
+      }
+
+      if (shorttext.Length == 1) {
+        // Single character string.
+        // After the previous speedup, the character can't be an equality.
+        diffs.Add(new Diff(Operation.DELETE, text1));
+        diffs.Add(new Diff(Operation.INSERT, text2));
+        return diffs;
+      }
+
+      // Check to see if the problem can be split in two.
+      string[] hm = diff_halfMatch(text1, text2);
+      if (hm != null) {
+        // A half-match was found, sort out the return data.
+        string text1_a = hm[0];
+        string text1_b = hm[1];
+        string text2_a = hm[2];
+        string text2_b = hm[3];
+        string mid_common = hm[4];
+        // Send both pairs off for separate processing.
+        List<Diff> diffs_a = diff_main(text1_a, text2_a, checklines, deadline);
+        List<Diff> diffs_b = diff_main(text1_b, text2_b, checklines, deadline);
+        // Merge the results.
+        diffs = diffs_a;
+        diffs.Add(new Diff(Operation.EQUAL, mid_common));
+        diffs.AddRange(diffs_b);
+        return diffs;
+      }
+
+      if (checklines && text1.Length > 100 && text2.Length > 100) {
+        return diff_lineMode(text1, text2, deadline);
+      }
+
+      return diff_bisect(text1, text2, deadline);
+    }
+
+    /**
+     * Do a quick line-level diff on both strings, then rediff the parts for
+     * greater accuracy.
+     * This speedup can produce non-minimal diffs.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param deadline Time when the diff should be complete by.
+     * @return List of Diff objects.
+     */
+    private List<Diff> diff_lineMode(string text1, string text2,
+                                     DateTime deadline) {
+      // Scan the text on a line-by-line basis first.
+      Object[] b = diff_linesToChars(text1, text2);
+      text1 = (string)b[0];
+      text2 = (string)b[1];
+      List<string> linearray = (List<string>)b[2];
+
+      List<Diff> diffs = diff_main(text1, text2, false, deadline);
+
+      // Convert the diff back to original text.
+      diff_charsToLines(diffs, linearray);
+      // Eliminate freak matches (e.g. blank lines)
+      diff_cleanupSemantic(diffs);
+
+      // Rediff any replacement blocks, this time character-by-character.
+      // Add a dummy entry at the end.
+      diffs.Add(new Diff(Operation.EQUAL, string.Empty));
+      int pointer = 0;
+      int count_delete = 0;
+      int count_insert = 0;
+      string text_delete = string.Empty;
+      string text_insert = string.Empty;
+      while (pointer < diffs.Count) {
+        switch (diffs[pointer].operation) {
+          case Operation.INSERT:
+            count_insert++;
+            text_insert += diffs[pointer].text;
+            break;
+          case Operation.DELETE:
+            count_delete++;
+            text_delete += diffs[pointer].text;
+            break;
+          case Operation.EQUAL:
+            // Upon reaching an equality, check for prior redundancies.
+            if (count_delete >= 1 && count_insert >= 1) {
+              // Delete the offending records and add the merged ones.
+              diffs.RemoveRange(pointer - count_delete - count_insert,
+                  count_delete + count_insert);
+              pointer = pointer - count_delete - count_insert;
+              List<Diff> a =
+                  this.diff_main(text_delete, text_insert, false, deadline);
+              diffs.InsertRange(pointer, a);
+              pointer = pointer + a.Count;
+            }
+            count_insert = 0;
+            count_delete = 0;
+            text_delete = string.Empty;
+            text_insert = string.Empty;
+            break;
+        }
+        pointer++;
+      }
+      diffs.RemoveAt(diffs.Count - 1);  // Remove the dummy entry at the end.
+
+      return diffs;
+    }
+
+    /**
+     * Find the 'middle snake' of a diff, split the problem in two
+     * and return the recursively constructed diff.
+     * See Myers 1986 paper: An O(ND) Difference Algorithm and Its Variations.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param deadline Time at which to bail if not yet complete.
+     * @return List of Diff objects.
+     */
+    protected List<Diff> diff_bisect(string text1, string text2,
+        DateTime deadline) {
+      // Cache the text lengths to prevent multiple calls.
+      int text1_length = text1.Length;
+      int text2_length = text2.Length;
+      int max_d = (text1_length + text2_length + 1) / 2;
+      int v_offset = max_d;
+      int v_length = 2 * max_d;
+      int[] v1 = new int[v_length];
+      int[] v2 = new int[v_length];
+      for (int x = 0; x < v_length; x++) {
+        v1[x] = -1;
+        v2[x] = -1;
+      }
+      v1[v_offset + 1] = 0;
+      v2[v_offset + 1] = 0;
+      int delta = text1_length - text2_length;
+      // If the total number of characters is odd, then the front path will
+      // collide with the reverse path.
+      bool front = (delta % 2 != 0);
+      // Offsets for start and end of k loop.
+      // Prevents mapping of space beyond the grid.
+      int k1start = 0;
+      int k1end = 0;
+      int k2start = 0;
+      int k2end = 0;
+      for (int d = 0; d < max_d; d++) {
+        // Bail out if deadline is reached.
+        if (DateTime.Now > deadline) {
+          break;
+        }
+
+        // Walk the front path one step.
+        for (int k1 = -d + k1start; k1 <= d - k1end; k1 += 2) {
+          int k1_offset = v_offset + k1;
+          int x1;
+          if (k1 == -d || k1 != d && v1[k1_offset - 1] < v1[k1_offset + 1]) {
+            x1 = v1[k1_offset + 1];
+          } else {
+            x1 = v1[k1_offset - 1] + 1;
+          }
+          int y1 = x1 - k1;
+          while (x1 < text1_length && y1 < text2_length
+                && text1[x1] == text2[y1]) {
+            x1++;
+            y1++;
+          }
+          v1[k1_offset] = x1;
+          if (x1 > text1_length) {
+            // Ran off the right of the graph.
+            k1end += 2;
+          } else if (y1 > text2_length) {
+            // Ran off the bottom of the graph.
+            k1start += 2;
+          } else if (front) {
+            int k2_offset = v_offset + delta - k1;
+            if (k2_offset >= 0 && k2_offset < v_length && v2[k2_offset] != -1) {
+              // Mirror x2 onto top-left coordinate system.
+              int x2 = text1_length - v2[k2_offset];
+              if (x1 >= x2) {
+                // Overlap detected.
+                return diff_bisectSplit(text1, text2, x1, y1, deadline);
+              }
+            }
+          }
+        }
+
+        // Walk the reverse path one step.
+        for (int k2 = -d + k2start; k2 <= d - k2end; k2 += 2) {
+          int k2_offset = v_offset + k2;
+          int x2;
+          if (k2 == -d || k2 != d && v2[k2_offset - 1] < v2[k2_offset + 1]) {
+            x2 = v2[k2_offset + 1];
+          } else {
+            x2 = v2[k2_offset - 1] + 1;
+          }
+          int y2 = x2 - k2;
+          while (x2 < text1_length && y2 < text2_length
+              && text1[text1_length - x2 - 1]
+              == text2[text2_length - y2 - 1]) {
+            x2++;
+            y2++;
+          }
+          v2[k2_offset] = x2;
+          if (x2 > text1_length) {
+            // Ran off the left of the graph.
+            k2end += 2;
+          } else if (y2 > text2_length) {
+            // Ran off the top of the graph.
+            k2start += 2;
+          } else if (!front) {
+            int k1_offset = v_offset + delta - k2;
+            if (k1_offset >= 0 && k1_offset < v_length && v1[k1_offset] != -1) {
+              int x1 = v1[k1_offset];
+              int y1 = v_offset + x1 - k1_offset;
+              // Mirror x2 onto top-left coordinate system.
+              x2 = text1_length - v2[k2_offset];
+              if (x1 >= x2) {
+                // Overlap detected.
+                return diff_bisectSplit(text1, text2, x1, y1, deadline);
+              }
+            }
+          }
+        }
+      }
+      // Diff took too long and hit the deadline or
+      // number of diffs equals number of characters, no commonality at all.
+      List<Diff> diffs = new List<Diff>();
+      diffs.Add(new Diff(Operation.DELETE, text1));
+      diffs.Add(new Diff(Operation.INSERT, text2));
+      return diffs;
+    }
+
+    /**
+     * Given the location of the 'middle snake', split the diff in two parts
+     * and recurse.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param x Index of split point in text1.
+     * @param y Index of split point in text2.
+     * @param deadline Time at which to bail if not yet complete.
+     * @return LinkedList of Diff objects.
+     */
+    private List<Diff> diff_bisectSplit(string text1, string text2,
+        int x, int y, DateTime deadline) {
+      string text1a = text1.Substring(0, x);
+      string text2a = text2.Substring(0, y);
+      string text1b = text1.Substring(x);
+      string text2b = text2.Substring(y);
+
+      // Compute both diffs serially.
+      List<Diff> diffs = diff_main(text1a, text2a, false, deadline);
+      List<Diff> diffsb = diff_main(text1b, text2b, false, deadline);
+
+      diffs.AddRange(diffsb);
+      return diffs;
+    }
+
+    /**
+     * Split two texts into a list of strings.  Reduce the texts to a string of
+     * hashes where each Unicode character represents one line.
+     * @param text1 First string.
+     * @param text2 Second string.
+     * @return Three element Object array, containing the encoded text1, the
+     *     encoded text2 and the List of unique strings.  The zeroth element
+     *     of the List of unique strings is intentionally blank.
+     */
+    protected Object[] diff_linesToChars(string text1, string text2) {
+      List<string> lineArray = new List<string>();
+      Dictionary<string, int> lineHash = new Dictionary<string, int>();
+      // e.g. linearray[4] == "Hello\n"
+      // e.g. linehash.get("Hello\n") == 4
+
+      // "\x00" is a valid character, but various debuggers don't like it.
+      // So we'll insert a junk entry to avoid generating a null character.
+      lineArray.Add(string.Empty);
+
+      string chars1 = diff_linesToCharsMunge(text1, lineArray, lineHash);
+      string chars2 = diff_linesToCharsMunge(text2, lineArray, lineHash);
+      return new Object[] { chars1, chars2, lineArray };
+    }
+
+    /**
+     * Split a text into a list of strings.  Reduce the texts to a string of
+     * hashes where each Unicode character represents one line.
+     * @param text String to encode.
+     * @param lineArray List of unique strings.
+     * @param lineHash Map of strings to indices.
+     * @return Encoded string.
+     */
+    private string diff_linesToCharsMunge(string text, List<string> lineArray,
+                                          Dictionary<string, int> lineHash) {
+      int lineStart = 0;
+      int lineEnd = -1;
+      string line;
+      StringBuilder chars = new StringBuilder();
+      // Walk the text, pulling out a Substring for each line.
+      // text.split('\n') would would temporarily double our memory footprint.
+      // Modifying text would create many large strings to garbage collect.
+      while (lineEnd < text.Length - 1) {
+        lineEnd = text.IndexOf('\n', lineStart);
+        if (lineEnd == -1) {
+          lineEnd = text.Length - 1;
+        }
+        line = text.JavaSubstring(lineStart, lineEnd + 1);
+        lineStart = lineEnd + 1;
+
+        if (lineHash.ContainsKey(line)) {
+          chars.Append(((char)(int)lineHash[line]));
+        } else {
+          lineArray.Add(line);
+          lineHash.Add(line, lineArray.Count - 1);
+          chars.Append(((char)(lineArray.Count - 1)));
+        }
+      }
+      return chars.ToString();
+    }
+
+    /**
+     * Rehydrate the text in a diff from a string of line hashes to real lines
+     * of text.
+     * @param diffs List of Diff objects.
+     * @param lineArray List of unique strings.
+     */
+    protected void diff_charsToLines(ICollection<Diff> diffs,
+                    List<string> lineArray) {
+      StringBuilder text;
+      foreach (Diff diff in diffs) {
+        text = new StringBuilder();
+        for (int y = 0; y < diff.text.Length; y++) {
+          text.Append(lineArray[diff.text[y]]);
+        }
+        diff.text = text.ToString();
+      }
+    }
+
+    /**
+     * Determine the common prefix of two strings.
+     * @param text1 First string.
+     * @param text2 Second string.
+     * @return The number of characters common to the start of each string.
+     */
+    public int diff_commonPrefix(string text1, string text2) {
+      // Performance analysis: http://neil.fraser.name/news/2007/10/09/
+      int n = Math.Min(text1.Length, text2.Length);
+      for (int i = 0; i < n; i++) {
+        if (text1[i] != text2[i]) {
+          return i;
+        }
+      }
+      return n;
+    }
+
+    /**
+     * Determine the common suffix of two strings.
+     * @param text1 First string.
+     * @param text2 Second string.
+     * @return The number of characters common to the end of each string.
+     */
+    public int diff_commonSuffix(string text1, string text2) {
+      // Performance analysis: http://neil.fraser.name/news/2007/10/09/
+      int text1_length = text1.Length;
+      int text2_length = text2.Length;
+      int n = Math.Min(text1.Length, text2.Length);
+      for (int i = 1; i <= n; i++) {
+        if (text1[text1_length - i] != text2[text2_length - i]) {
+          return i - 1;
+        }
+      }
+      return n;
+    }
+
+    /**
+     * Determine if the suffix of one string is the prefix of another.
+     * @param text1 First string.
+     * @param text2 Second string.
+     * @return The number of characters common to the end of the first
+     *     string and the start of the second string.
+     */
+    protected int diff_commonOverlap(string text1, string text2) {
+      // Cache the text lengths to prevent multiple calls.
+      int text1_length = text1.Length;
+      int text2_length = text2.Length;
+      // Eliminate the null case.
+      if (text1_length == 0 || text2_length == 0) {
+        return 0;
+      }
+      // Truncate the longer string.
+      if (text1_length > text2_length) {
+        text1 = text1.Substring(text1_length - text2_length);
+      } else if (text1_length < text2_length) {
+        text2 = text2.Substring(0, text1_length);
+      }
+      int text_length = Math.Min(text1_length, text2_length);
+      // Quick check for the worst case.
+      if (text1 == text2) {
+        return text_length;
+      }
+
+      // Start by looking for a single character match
+      // and increase length until no match is found.
+      // Performance analysis: http://neil.fraser.name/news/2010/11/04/
+      int best = 0;
+      int length = 1;
+      while (true) {
+        string pattern = text1.Substring(text_length - length);
+        int found = text2.IndexOf(pattern, StringComparison.Ordinal);
+        if (found == -1) {
+          return best;
+        }
+        length += found;
+        if (found == 0 || text1.Substring(text_length - length) ==
+            text2.Substring(0, length)) {
+          best = length;
+          length++;
+        }
+      }
+    }
+
+    /**
+     * Do the two texts share a Substring which is at least half the length of
+     * the longer text?
+     * This speedup can produce non-minimal diffs.
+     * @param text1 First string.
+     * @param text2 Second string.
+     * @return Five element String array, containing the prefix of text1, the
+     *     suffix of text1, the prefix of text2, the suffix of text2 and the
+     *     common middle.  Or null if there was no match.
+     */
+
+    protected string[] diff_halfMatch(string text1, string text2) {
+      if (this.Diff_Timeout <= 0) {
+        // Don't risk returning a non-optimal diff if we have unlimited time.
+        return null;
+      }
+      string longtext = text1.Length > text2.Length ? text1 : text2;
+      string shorttext = text1.Length > text2.Length ? text2 : text1;
+      if (longtext.Length < 4 || shorttext.Length * 2 < longtext.Length) {
+        return null;  // Pointless.
+      }
+
+      // First check if the second quarter is the seed for a half-match.
+      string[] hm1 = diff_halfMatchI(longtext, shorttext,
+                                     (longtext.Length + 3) / 4);
+      // Check again based on the third quarter.
+      string[] hm2 = diff_halfMatchI(longtext, shorttext,
+                                     (longtext.Length + 1) / 2);
+      string[] hm;
+      if (hm1 == null && hm2 == null) {
+        return null;
+      } else if (hm2 == null) {
+        hm = hm1;
+      } else if (hm1 == null) {
+        hm = hm2;
+      } else {
+        // Both matched.  Select the longest.
+        hm = hm1[4].Length > hm2[4].Length ? hm1 : hm2;
+      }
+
+      // A half-match was found, sort out the return data.
+      if (text1.Length > text2.Length) {
+        return hm;
+        //return new string[]{hm[0], hm[1], hm[2], hm[3], hm[4]};
+      } else {
+        return new string[] { hm[2], hm[3], hm[0], hm[1], hm[4] };
+      }
+    }
+
+    /**
+     * Does a Substring of shorttext exist within longtext such that the
+     * Substring is at least half the length of longtext?
+     * @param longtext Longer string.
+     * @param shorttext Shorter string.
+     * @param i Start index of quarter length Substring within longtext.
+     * @return Five element string array, containing the prefix of longtext, the
+     *     suffix of longtext, the prefix of shorttext, the suffix of shorttext
+     *     and the common middle.  Or null if there was no match.
+     */
+    private string[] diff_halfMatchI(string longtext, string shorttext, int i) {
+      // Start with a 1/4 length Substring at position i as a seed.
+      string seed = longtext.Substring(i, longtext.Length / 4);
+      int j = -1;
+      string best_common = string.Empty;
+      string best_longtext_a = string.Empty, best_longtext_b = string.Empty;
+      string best_shorttext_a = string.Empty, best_shorttext_b = string.Empty;
+      while (j < shorttext.Length && (j = shorttext.IndexOf(seed, j + 1,
+          StringComparison.Ordinal)) != -1) {
+        int prefixLength = diff_commonPrefix(longtext.Substring(i),
+                                             shorttext.Substring(j));
+        int suffixLength = diff_commonSuffix(longtext.Substring(0, i),
+                                             shorttext.Substring(0, j));
+        if (best_common.Length < suffixLength + prefixLength) {
+          best_common = shorttext.Substring(j - suffixLength, suffixLength)
+              + shorttext.Substring(j, prefixLength);
+          best_longtext_a = longtext.Substring(0, i - suffixLength);
+          best_longtext_b = longtext.Substring(i + prefixLength);
+          best_shorttext_a = shorttext.Substring(0, j - suffixLength);
+          best_shorttext_b = shorttext.Substring(j + prefixLength);
+        }
+      }
+      if (best_common.Length * 2 >= longtext.Length) {
+        return new string[]{best_longtext_a, best_longtext_b,
+            best_shorttext_a, best_shorttext_b, best_common};
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * Reduce the number of edits by eliminating semantically trivial
+     * equalities.
+     * @param diffs List of Diff objects.
+     */
+    public void diff_cleanupSemantic(List<Diff> diffs) {
+      bool changes = false;
+      // Stack of indices where equalities are found.
+      Stack<int> equalities = new Stack<int>();
+      // Always equal to equalities[equalitiesLength-1][1]
+      string lastequality = null;
+      int pointer = 0;  // Index of current position.
+      // Number of characters that changed prior to the equality.
+      int length_insertions1 = 0;
+      int length_deletions1 = 0;
+      // Number of characters that changed after the equality.
+      int length_insertions2 = 0;
+      int length_deletions2 = 0;
+      while (pointer < diffs.Count) {
+        if (diffs[pointer].operation == Operation.EQUAL) {  // Equality found.
+          equalities.Push(pointer);
+          length_insertions1 = length_insertions2;
+          length_deletions1 = length_deletions2;
+          length_insertions2 = 0;
+          length_deletions2 = 0;
+          lastequality = diffs[pointer].text;
+        } else {  // an insertion or deletion
+          if (diffs[pointer].operation == Operation.INSERT) {
+            length_insertions2 += diffs[pointer].text.Length;
+          } else {
+            length_deletions2 += diffs[pointer].text.Length;
+          }
+          // Eliminate an equality that is smaller or equal to the edits on both
+          // sides of it.
+          if (lastequality != null && (lastequality.Length
+              <= Math.Max(length_insertions1, length_deletions1))
+              && (lastequality.Length
+                  <= Math.Max(length_insertions2, length_deletions2))) {
+            // Duplicate record.
+            diffs.Insert(equalities.Peek(),
+                         new Diff(Operation.DELETE, lastequality));
+            // Change second copy to insert.
+            diffs[equalities.Peek() + 1].operation = Operation.INSERT;
+            // Throw away the equality we just deleted.
+            equalities.Pop();
+            if (equalities.Count > 0) {
+              equalities.Pop();
+            }
+            pointer = equalities.Count > 0 ? equalities.Peek() : -1;
+            length_insertions1 = 0;  // Reset the counters.
+            length_deletions1 = 0;
+            length_insertions2 = 0;
+            length_deletions2 = 0;
+            lastequality = null;
+            changes = true;
+          }
+        }
+        pointer++;
+      }
+
+      // Normalize the diff.
+      if (changes) {
+        diff_cleanupMerge(diffs);
+      }
+      diff_cleanupSemanticLossless(diffs);
+
+      // Find any overlaps between deletions and insertions.
+      // e.g: <del>abcxxx</del><ins>xxxdef</ins>
+      //   -> <del>abc</del>xxx<ins>def</ins>
+      // e.g: <del>xxxabc</del><ins>defxxx</ins>
+      //   -> <ins>def</ins>xxx<del>abc</del>
+      // Only extract an overlap if it is as big as the edit ahead or behind it.
+      pointer = 1;
+      while (pointer < diffs.Count) {
+        if (diffs[pointer - 1].operation == Operation.DELETE &&
+            diffs[pointer].operation == Operation.INSERT) {
+          string deletion = diffs[pointer - 1].text;
+          string insertion = diffs[pointer].text;
+          int overlap_length1 = diff_commonOverlap(deletion, insertion);
+          int overlap_length2 = diff_commonOverlap(insertion, deletion);
+          if (overlap_length1 >= overlap_length2) {
+            if (overlap_length1 >= deletion.Length / 2.0 ||
+                overlap_length1 >= insertion.Length / 2.0) {
+              // Overlap found.
+              // Insert an equality and trim the surrounding edits.
+              diffs.Insert(pointer, new Diff(Operation.EQUAL,
+                  insertion.Substring(0, overlap_length1)));
+              diffs[pointer - 1].text =
+                  deletion.Substring(0, deletion.Length - overlap_length1);
+              diffs[pointer + 1].text = insertion.Substring(overlap_length1);
+              pointer++;
+            }
+          } else {
+            if (overlap_length2 >= deletion.Length / 2.0 ||
+                overlap_length2 >= insertion.Length / 2.0) {
+              // Reverse overlap found.
+              // Insert an equality and swap and trim the surrounding edits.
+              diffs.Insert(pointer, new Diff(Operation.EQUAL,
+                  deletion.Substring(0, overlap_length2)));
+              diffs[pointer - 1].operation = Operation.INSERT;
+              diffs[pointer - 1].text =
+                  insertion.Substring(0, insertion.Length - overlap_length2);
+              diffs[pointer + 1].operation = Operation.DELETE;
+              diffs[pointer + 1].text = deletion.Substring(overlap_length2);
+              pointer++;
+            }
+          }
+          pointer++;
+        }
+        pointer++;
+      }
+    }
+
+    /**
+     * Look for single edits surrounded on both sides by equalities
+     * which can be shifted sideways to align the edit to a word boundary.
+     * e.g: The c<ins>at c</ins>ame. -> The <ins>cat </ins>came.
+     * @param diffs List of Diff objects.
+     */
+    public void diff_cleanupSemanticLossless(List<Diff> diffs) {
+      int pointer = 1;
+      // Intentionally ignore the first and last element (don't need checking).
+      while (pointer < diffs.Count - 1) {
+        if (diffs[pointer - 1].operation == Operation.EQUAL &&
+          diffs[pointer + 1].operation == Operation.EQUAL) {
+          // This is a single edit surrounded by equalities.
+          string equality1 = diffs[pointer - 1].text;
+          string edit = diffs[pointer].text;
+          string equality2 = diffs[pointer + 1].text;
+
+          // First, shift the edit as far left as possible.
+          int commonOffset = this.diff_commonSuffix(equality1, edit);
+          if (commonOffset > 0) {
+            string commonString = edit.Substring(edit.Length - commonOffset);
+            equality1 = equality1.Substring(0, equality1.Length - commonOffset);
+            edit = commonString + edit.Substring(0, edit.Length - commonOffset);
+            equality2 = commonString + equality2;
+          }
+
+          // Second, step character by character right,
+          // looking for the best fit.
+          string bestEquality1 = equality1;
+          string bestEdit = edit;
+          string bestEquality2 = equality2;
+          int bestScore = diff_cleanupSemanticScore(equality1, edit) +
+              diff_cleanupSemanticScore(edit, equality2);
+          while (edit.Length != 0 && equality2.Length != 0
+              && edit[0] == equality2[0]) {
+            equality1 += edit[0];
+            edit = edit.Substring(1) + equality2[0];
+            equality2 = equality2.Substring(1);
+            int score = diff_cleanupSemanticScore(equality1, edit) +
+                diff_cleanupSemanticScore(edit, equality2);
+            // The >= encourages trailing rather than leading whitespace on
+            // edits.
+            if (score >= bestScore) {
+              bestScore = score;
+              bestEquality1 = equality1;
+              bestEdit = edit;
+              bestEquality2 = equality2;
+            }
+          }
+
+          if (diffs[pointer - 1].text != bestEquality1) {
+            // We have an improvement, save it back to the diff.
+            if (bestEquality1.Length != 0) {
+              diffs[pointer - 1].text = bestEquality1;
+            } else {
+              diffs.RemoveAt(pointer - 1);
+              pointer--;
+            }
+            diffs[pointer].text = bestEdit;
+            if (bestEquality2.Length != 0) {
+              diffs[pointer + 1].text = bestEquality2;
+            } else {
+              diffs.RemoveAt(pointer + 1);
+              pointer--;
+            }
+          }
+        }
+        pointer++;
+      }
+    }
+
+    /**
+     * Given two strings, comAdde a score representing whether the internal
+     * boundary falls on logical boundaries.
+     * Scores range from 6 (best) to 0 (worst).
+     * @param one First string.
+     * @param two Second string.
+     * @return The score.
+     */
+    private int diff_cleanupSemanticScore(string one, string two) {
+      if (one.Length == 0 || two.Length == 0) {
+        // Edges are the best.
+        return 6;
+      }
+
+      // Each port of this function behaves slightly differently due to
+      // subtle differences in each language's definition of things like
+      // 'whitespace'.  Since this function's purpose is largely cosmetic,
+      // the choice has been made to use each language's native features
+      // rather than force total conformity.
+      char char1 = one[one.Length - 1];
+      char char2 = two[0];
+      bool nonAlphaNumeric1 = !Char.IsLetterOrDigit(char1);
+      bool nonAlphaNumeric2 = !Char.IsLetterOrDigit(char2);
+      bool whitespace1 = nonAlphaNumeric1 && Char.IsWhiteSpace(char1);
+      bool whitespace2 = nonAlphaNumeric2 && Char.IsWhiteSpace(char2);
+      bool lineBreak1 = whitespace1 && Char.IsControl(char1);
+      bool lineBreak2 = whitespace2 && Char.IsControl(char2);
+      bool blankLine1 = lineBreak1 && BLANKLINEEND.IsMatch(one);
+      bool blankLine2 = lineBreak2 && BLANKLINESTART.IsMatch(two);
+
+      if (blankLine1 || blankLine2) {
+        // Five points for blank lines.
+        return 5;
+      } else if (lineBreak1 || lineBreak2) {
+        // Four points for line breaks.
+        return 4;
+      } else if (nonAlphaNumeric1 && !whitespace1 && whitespace2) {
+        // Three points for end of sentences.
+        return 3;
+      } else if (whitespace1 || whitespace2) {
+        // Two points for whitespace.
+        return 2;
+      } else if (nonAlphaNumeric1 || nonAlphaNumeric2) {
+        // One point for non-alphanumeric.
+        return 1;
+      }
+      return 0;
+    }
+
+    // Define some regex patterns for matching boundaries.
+    private Regex BLANKLINEEND = new Regex("\\n\\r?\\n\\Z");
+    private Regex BLANKLINESTART = new Regex("\\A\\r?\\n\\r?\\n");
+
+    /**
+     * Reduce the number of edits by eliminating operationally trivial
+     * equalities.
+     * @param diffs List of Diff objects.
+     */
+    public void diff_cleanupEfficiency(List<Diff> diffs) {
+      bool changes = false;
+      // Stack of indices where equalities are found.
+      Stack<int> equalities = new Stack<int>();
+      // Always equal to equalities[equalitiesLength-1][1]
+      string lastequality = string.Empty;
+      int pointer = 0;  // Index of current position.
+      // Is there an insertion operation before the last equality.
+      bool pre_ins = false;
+      // Is there a deletion operation before the last equality.
+      bool pre_del = false;
+      // Is there an insertion operation after the last equality.
+      bool post_ins = false;
+      // Is there a deletion operation after the last equality.
+      bool post_del = false;
+      while (pointer < diffs.Count) {
+        if (diffs[pointer].operation == Operation.EQUAL) {  // Equality found.
+          if (diffs[pointer].text.Length < this.Diff_EditCost
+              && (post_ins || post_del)) {
+            // Candidate found.
+            equalities.Push(pointer);
+            pre_ins = post_ins;
+            pre_del = post_del;
+            lastequality = diffs[pointer].text;
+          } else {
+            // Not a candidate, and can never become one.
+            equalities.Clear();
+            lastequality = string.Empty;
+          }
+          post_ins = post_del = false;
+        } else {  // An insertion or deletion.
+          if (diffs[pointer].operation == Operation.DELETE) {
+            post_del = true;
+          } else {
+            post_ins = true;
+          }
+          /*
+           * Five types to be split:
+           * <ins>A</ins><del>B</del>XY<ins>C</ins><del>D</del>
+           * <ins>A</ins>X<ins>C</ins><del>D</del>
+           * <ins>A</ins><del>B</del>X<ins>C</ins>
+           * <ins>A</del>X<ins>C</ins><del>D</del>
+           * <ins>A</ins><del>B</del>X<del>C</del>
+           */
+          if ((lastequality.Length != 0)
+              && ((pre_ins && pre_del && post_ins && post_del)
+              || ((lastequality.Length < this.Diff_EditCost / 2)
+              && ((pre_ins ? 1 : 0) + (pre_del ? 1 : 0) + (post_ins ? 1 : 0)
+              + (post_del ? 1 : 0)) == 3))) {
+            // Duplicate record.
+            diffs.Insert(equalities.Peek(),
+                         new Diff(Operation.DELETE, lastequality));
+            // Change second copy to insert.
+            diffs[equalities.Peek() + 1].operation = Operation.INSERT;
+            equalities.Pop();  // Throw away the equality we just deleted.
+            lastequality = string.Empty;
+            if (pre_ins && pre_del) {
+              // No changes made which could affect previous entry, keep going.
+              post_ins = post_del = true;
+              equalities.Clear();
+            } else {
+              if (equalities.Count > 0) {
+                equalities.Pop();
+              }
+
+              pointer = equalities.Count > 0 ? equalities.Peek() : -1;
+              post_ins = post_del = false;
+            }
+            changes = true;
+          }
+        }
+        pointer++;
+      }
+
+      if (changes) {
+        diff_cleanupMerge(diffs);
+      }
+    }
+
+    /**
+     * Reorder and merge like edit sections.  Merge equalities.
+     * Any edit section can move as long as it doesn't cross an equality.
+     * @param diffs List of Diff objects.
+     */
+    public void diff_cleanupMerge(List<Diff> diffs) {
+      // Add a dummy entry at the end.
+      diffs.Add(new Diff(Operation.EQUAL, string.Empty));
+      int pointer = 0;
+      int count_delete = 0;
+      int count_insert = 0;
+      string text_delete = string.Empty;
+      string text_insert = string.Empty;
+      int commonlength;
+      while (pointer < diffs.Count) {
+        switch (diffs[pointer].operation) {
+          case Operation.INSERT:
+            count_insert++;
+            text_insert += diffs[pointer].text;
+            pointer++;
+            break;
+          case Operation.DELETE:
+            count_delete++;
+            text_delete += diffs[pointer].text;
+            pointer++;
+            break;
+          case Operation.EQUAL:
+            // Upon reaching an equality, check for prior redundancies.
+            if (count_delete + count_insert > 1) {
+              if (count_delete != 0 && count_insert != 0) {
+                // Factor out any common prefixies.
+                commonlength = this.diff_commonPrefix(text_insert, text_delete);
+                if (commonlength != 0) {
+                  if ((pointer - count_delete - count_insert) > 0 &&
+                    diffs[pointer - count_delete - count_insert - 1].operation
+                        == Operation.EQUAL) {
+                    diffs[pointer - count_delete - count_insert - 1].text
+                        += text_insert.Substring(0, commonlength);
+                  } else {
+                    diffs.Insert(0, new Diff(Operation.EQUAL,
+                        text_insert.Substring(0, commonlength)));
+                    pointer++;
+                  }
+                  text_insert = text_insert.Substring(commonlength);
+                  text_delete = text_delete.Substring(commonlength);
+                }
+                // Factor out any common suffixies.
+                commonlength = this.diff_commonSuffix(text_insert, text_delete);
+                if (commonlength != 0) {
+                  diffs[pointer].text = text_insert.Substring(text_insert.Length
+                      - commonlength) + diffs[pointer].text;
+                  text_insert = text_insert.Substring(0, text_insert.Length
+                      - commonlength);
+                  text_delete = text_delete.Substring(0, text_delete.Length
+                      - commonlength);
+                }
+              }
+              // Delete the offending records and add the merged ones.
+              if (count_delete == 0) {
+                diffs.Splice(pointer - count_insert,
+                    count_delete + count_insert,
+                    new Diff(Operation.INSERT, text_insert));
+              } else if (count_insert == 0) {
+                diffs.Splice(pointer - count_delete,
+                    count_delete + count_insert,
+                    new Diff(Operation.DELETE, text_delete));
+              } else {
+                diffs.Splice(pointer - count_delete - count_insert,
+                    count_delete + count_insert,
+                    new Diff(Operation.DELETE, text_delete),
+                    new Diff(Operation.INSERT, text_insert));
+              }
+              pointer = pointer - count_delete - count_insert +
+                  (count_delete != 0 ? 1 : 0) + (count_insert != 0 ? 1 : 0) + 1;
+            } else if (pointer != 0
+                && diffs[pointer - 1].operation == Operation.EQUAL) {
+              // Merge this equality with the previous one.
+              diffs[pointer - 1].text += diffs[pointer].text;
+              diffs.RemoveAt(pointer);
+            } else {
+              pointer++;
+            }
+            count_insert = 0;
+            count_delete = 0;
+            text_delete = string.Empty;
+            text_insert = string.Empty;
+            break;
+        }
+      }
+      if (diffs[diffs.Count - 1].text.Length == 0) {
+        diffs.RemoveAt(diffs.Count - 1);  // Remove the dummy entry at the end.
+      }
+
+      // Second pass: look for single edits surrounded on both sides by
+      // equalities which can be shifted sideways to eliminate an equality.
+      // e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
+      bool changes = false;
+      pointer = 1;
+      // Intentionally ignore the first and last element (don't need checking).
+      while (pointer < (diffs.Count - 1)) {
+        if (diffs[pointer - 1].operation == Operation.EQUAL &&
+          diffs[pointer + 1].operation == Operation.EQUAL) {
+          // This is a single edit surrounded by equalities.
+          if (diffs[pointer].text.EndsWith(diffs[pointer - 1].text,
+              StringComparison.Ordinal)) {
+            // Shift the edit over the previous equality.
+            diffs[pointer].text = diffs[pointer - 1].text +
+                diffs[pointer].text.Substring(0, diffs[pointer].text.Length -
+                                              diffs[pointer - 1].text.Length);
+            diffs[pointer + 1].text = diffs[pointer - 1].text
+                + diffs[pointer + 1].text;
+            diffs.Splice(pointer - 1, 1);
+            changes = true;
+          } else if (diffs[pointer].text.StartsWith(diffs[pointer + 1].text,
+              StringComparison.Ordinal)) {
+            // Shift the edit over the next equality.
+            diffs[pointer - 1].text += diffs[pointer + 1].text;
+            diffs[pointer].text =
+                diffs[pointer].text.Substring(diffs[pointer + 1].text.Length)
+                + diffs[pointer + 1].text;
+            diffs.Splice(pointer + 1, 1);
+            changes = true;
+          }
+        }
+        pointer++;
+      }
+      // If shifts were made, the diff needs reordering and another shift sweep.
+      if (changes) {
+        this.diff_cleanupMerge(diffs);
+      }
+    }
+
+    /**
+     * loc is a location in text1, comAdde and return the equivalent location in
+     * text2.
+     * e.g. "The cat" vs "The big cat", 1->1, 5->8
+     * @param diffs List of Diff objects.
+     * @param loc Location within text1.
+     * @return Location within text2.
+     */
+    public int diff_xIndex(List<Diff> diffs, int loc) {
+      int chars1 = 0;
+      int chars2 = 0;
+      int last_chars1 = 0;
+      int last_chars2 = 0;
+      Diff lastDiff = null;
+      foreach (Diff aDiff in diffs) {
+        if (aDiff.operation != Operation.INSERT) {
+          // Equality or deletion.
+          chars1 += aDiff.text.Length;
+        }
+        if (aDiff.operation != Operation.DELETE) {
+          // Equality or insertion.
+          chars2 += aDiff.text.Length;
+        }
+        if (chars1 > loc) {
+          // Overshot the location.
+          lastDiff = aDiff;
+          break;
+        }
+        last_chars1 = chars1;
+        last_chars2 = chars2;
+      }
+      if (lastDiff != null && lastDiff.operation == Operation.DELETE) {
+        // The location was deleted.
+        return last_chars2;
+      }
+      // Add the remaining character length.
+      return last_chars2 + (loc - last_chars1);
+    }
+
+    /**
+     * Convert a Diff list into a pretty HTML report.
+     * @param diffs List of Diff objects.
+     * @return HTML representation.
+     */
+    public string diff_prettyHtml(List<Diff> diffs) {
+      StringBuilder html = new StringBuilder();
+      foreach (Diff aDiff in diffs) {
+        string text = aDiff.text.Replace("&", "&amp;").Replace("<", "&lt;")
+          .Replace(">", "&gt;").Replace("\n", "&para;<br>");
+        switch (aDiff.operation) {
+          case Operation.INSERT:
+            html.Append("<ins style=\"background:#e6ffe6;\">").Append(text)
+                .Append("</ins>");
+            break;
+          case Operation.DELETE:
+            html.Append("<del style=\"background:#ffe6e6;\">").Append(text)
+                .Append("</del>");
+            break;
+          case Operation.EQUAL:
+            html.Append("<span>").Append(text).Append("</span>");
+            break;
+        }
+      }
+      return html.ToString();
+    }
+
+    /**
+     * Compute and return the source text (all equalities and deletions).
+     * @param diffs List of Diff objects.
+     * @return Source text.
+     */
+    public string diff_text1(List<Diff> diffs) {
+      StringBuilder text = new StringBuilder();
+      foreach (Diff aDiff in diffs) {
+        if (aDiff.operation != Operation.INSERT) {
+          text.Append(aDiff.text);
+        }
+      }
+      return text.ToString();
+    }
+
+    /**
+     * Compute and return the destination text (all equalities and insertions).
+     * @param diffs List of Diff objects.
+     * @return Destination text.
+     */
+    public string diff_text2(List<Diff> diffs) {
+      StringBuilder text = new StringBuilder();
+      foreach (Diff aDiff in diffs) {
+        if (aDiff.operation != Operation.DELETE) {
+          text.Append(aDiff.text);
+        }
+      }
+      return text.ToString();
+    }
+
+    /**
+     * Compute the Levenshtein distance; the number of inserted, deleted or
+     * substituted characters.
+     * @param diffs List of Diff objects.
+     * @return Number of changes.
+     */
+    public int diff_levenshtein(List<Diff> diffs) {
+      int levenshtein = 0;
+      int insertions = 0;
+      int deletions = 0;
+      foreach (Diff aDiff in diffs) {
+        switch (aDiff.operation) {
+          case Operation.INSERT:
+            insertions += aDiff.text.Length;
+            break;
+          case Operation.DELETE:
+            deletions += aDiff.text.Length;
+            break;
+          case Operation.EQUAL:
+            // A deletion and an insertion is one substitution.
+            levenshtein += Math.Max(insertions, deletions);
+            insertions = 0;
+            deletions = 0;
+            break;
+        }
+      }
+      levenshtein += Math.Max(insertions, deletions);
+      return levenshtein;
+    }
+
+    /**
+     * Crush the diff into an encoded string which describes the operations
+     * required to transform text1 into text2.
+     * E.g. =3\t-2\t+ing  -> Keep 3 chars, delete 2 chars, insert 'ing'.
+     * Operations are tab-separated.  Inserted text is escaped using %xx
+     * notation.
+     * @param diffs Array of Diff objects.
+     * @return Delta text.
+     */
+    public string diff_toDelta(List<Diff> diffs) {
+      StringBuilder text = new StringBuilder();
+      foreach (Diff aDiff in diffs) {
+        switch (aDiff.operation) {
+          case Operation.INSERT:
+            text.Append("+").Append(RestSharp.Contrib.HttpUtility.UrlEncode(aDiff.text,
+                new UTF8Encoding()).Replace('+', ' ')).Append("\t");
+            break;
+          case Operation.DELETE:
+            text.Append("-").Append(aDiff.text.Length).Append("\t");
+            break;
+          case Operation.EQUAL:
+            text.Append("=").Append(aDiff.text.Length).Append("\t");
+            break;
+        }
+      }
+      string delta = text.ToString();
+      if (delta.Length != 0) {
+        // Strip off trailing tab character.
+        delta = delta.Substring(0, delta.Length - 1);
+        delta = unescapeForEncodeUriCompatability(delta);
+      }
+      return delta;
+    }
+
+    /**
+     * Given the original text1, and an encoded string which describes the
+     * operations required to transform text1 into text2, comAdde the full diff.
+     * @param text1 Source string for the diff.
+     * @param delta Delta text.
+     * @return Array of Diff objects or null if invalid.
+     * @throws ArgumentException If invalid input.
+     */
+    public List<Diff> diff_fromDelta(string text1, string delta) {
+      List<Diff> diffs = new List<Diff>();
+      int pointer = 0;  // Cursor in text1
+      string[] tokens = delta.Split(new string[] { "\t" },
+          StringSplitOptions.None);
+      foreach (string token in tokens) {
+        if (token.Length == 0) {
+          // Blank tokens are ok (from a trailing \t).
+          continue;
+        }
+        // Each token begins with a one character parameter which specifies the
+        // operation of this token (delete, insert, equality).
+        string param = token.Substring(1);
+        switch (token[0]) {
+          case '+':
+            // decode would change all "+" to " "
+            param = param.Replace("+", "%2b");
+
+            param = RestSharp.Contrib.HttpUtility.UrlDecode(param, new UTF8Encoding(false, true));
+            //} catch (UnsupportedEncodingException e) {
+            //  // Not likely on modern system.
+            //  throw new Error("This system does not support UTF-8.", e);
+            //} catch (IllegalArgumentException e) {
+            //  // Malformed URI sequence.
+            //  throw new IllegalArgumentException(
+            //      "Illegal escape in diff_fromDelta: " + param, e);
+            //}
+            diffs.Add(new Diff(Operation.INSERT, param));
+            break;
+          case '-':
+            // Fall through.
+          case '=':
+            int n;
+            try {
+              n = Convert.ToInt32(param);
+            } catch (FormatException e) {
+              throw new ArgumentException(
+                  "Invalid number in diff_fromDelta: " + param, e);
+            }
+            if (n < 0) {
+              throw new ArgumentException(
+                  "Negative number in diff_fromDelta: " + param);
+            }
+            string text;
+            try {
+              text = text1.Substring(pointer, n);
+              pointer += n;
+            } catch (ArgumentOutOfRangeException e) {
+              throw new ArgumentException("Delta length (" + pointer
+                  + ") larger than source text length (" + text1.Length
+                  + ").", e);
+            }
+            if (token[0] == '=') {
+              diffs.Add(new Diff(Operation.EQUAL, text));
+            } else {
+              diffs.Add(new Diff(Operation.DELETE, text));
+            }
+            break;
+          default:
+            // Anything else is an error.
+            throw new ArgumentException(
+                "Invalid diff operation in diff_fromDelta: " + token[0]);
+        }
+      }
+      if (pointer != text1.Length) {
+        throw new ArgumentException("Delta length (" + pointer
+            + ") smaller than source text length (" + text1.Length + ").");
+      }
+      return diffs;
+    }
+
+
+    //  MATCH FUNCTIONS
+
+
+    /**
+     * Locate the best instance of 'pattern' in 'text' near 'loc'.
+     * Returns -1 if no match found.
+     * @param text The text to search.
+     * @param pattern The pattern to search for.
+     * @param loc The location to search around.
+     * @return Best match index or -1.
+     */
+    public int match_main(string text, string pattern, int loc) {
+      // Check for null inputs not needed since null can't be passed in C#.
+
+      loc = Math.Max(0, Math.Min(loc, text.Length));
+      if (text == pattern) {
+        // Shortcut (potentially not guaranteed by the algorithm)
+        return 0;
+      } else if (text.Length == 0) {
+        // Nothing to match.
+        return -1;
+      } else if (loc + pattern.Length <= text.Length
+        && text.Substring(loc, pattern.Length) == pattern) {
+        // Perfect match at the perfect spot!  (Includes case of null pattern)
+        return loc;
+      } else {
+        // Do a fuzzy compare.
+        return match_bitap(text, pattern, loc);
+      }
+    }
+
+    /**
+     * Locate the best instance of 'pattern' in 'text' near 'loc' using the
+     * Bitap algorithm.  Returns -1 if no match found.
+     * @param text The text to search.
+     * @param pattern The pattern to search for.
+     * @param loc The location to search around.
+     * @return Best match index or -1.
+     */
+    protected int match_bitap(string text, string pattern, int loc) {
+      // assert (Match_MaxBits == 0 || pattern.Length <= Match_MaxBits)
+      //    : "Pattern too long for this application.";
+
+      // Initialise the alphabet.
+      Dictionary<char, int> s = match_alphabet(pattern);
+
+      // Highest score beyond which we give up.
+      double score_threshold = Match_Threshold;
+      // Is there a nearby exact match? (speedup)
+      int best_loc = text.IndexOf(pattern, loc, StringComparison.Ordinal);
+      if (best_loc != -1) {
+        score_threshold = Math.Min(match_bitapScore(0, best_loc, loc,
+            pattern), score_threshold);
+        // What about in the other direction? (speedup)
+        best_loc = text.LastIndexOf(pattern,
+            Math.Min(loc + pattern.Length, text.Length),
+            StringComparison.Ordinal);
+        if (best_loc != -1) {
+          score_threshold = Math.Min(match_bitapScore(0, best_loc, loc,
+              pattern), score_threshold);
+        }
+      }
+
+      // Initialise the bit arrays.
+      int matchmask = 1 << (pattern.Length - 1);
+      best_loc = -1;
+
+      int bin_min, bin_mid;
+      int bin_max = pattern.Length + text.Length;
+      // Empty initialization added to appease C# compiler.
+      int[] last_rd = new int[0];
+      for (int d = 0; d < pattern.Length; d++) {
+        // Scan for the best match; each iteration allows for one more error.
+        // Run a binary search to determine how far from 'loc' we can stray at
+        // this error level.
+        bin_min = 0;
+        bin_mid = bin_max;
+        while (bin_min < bin_mid) {
+          if (match_bitapScore(d, loc + bin_mid, loc, pattern)
+              <= score_threshold) {
+            bin_min = bin_mid;
+          } else {
+            bin_max = bin_mid;
+          }
+          bin_mid = (bin_max - bin_min) / 2 + bin_min;
+        }
+        // Use the result from this iteration as the maximum for the next.
+        bin_max = bin_mid;
+        int start = Math.Max(1, loc - bin_mid + 1);
+        int finish = Math.Min(loc + bin_mid, text.Length) + pattern.Length;
+
+        int[] rd = new int[finish + 2];
+        rd[finish + 1] = (1 << d) - 1;
+        for (int j = finish; j >= start; j--) {
+          int charMatch;
+          if (text.Length <= j - 1 || !s.ContainsKey(text[j - 1])) {
+            // Out of range.
+            charMatch = 0;
+          } else {
+            charMatch = s[text[j - 1]];
+          }
+          if (d == 0) {
+            // First pass: exact match.
+            rd[j] = ((rd[j + 1] << 1) | 1) & charMatch;
+          } else {
+            // Subsequent passes: fuzzy match.
+            rd[j] = ((rd[j + 1] << 1) | 1) & charMatch
+                | (((last_rd[j + 1] | last_rd[j]) << 1) | 1) | last_rd[j + 1];
+          }
+          if ((rd[j] & matchmask) != 0) {
+            double score = match_bitapScore(d, j - 1, loc, pattern);
+            // This match will almost certainly be better than any existing
+            // match.  But check anyway.
+            if (score <= score_threshold) {
+              // Told you so.
+              score_threshold = score;
+              best_loc = j - 1;
+              if (best_loc > loc) {
+                // When passing loc, don't exceed our current distance from loc.
+                start = Math.Max(1, 2 * loc - best_loc);
+              } else {
+                // Already passed loc, downhill from here on in.
+                break;
+              }
+            }
+          }
+        }
+        if (match_bitapScore(d + 1, loc, loc, pattern) > score_threshold) {
+          // No hope for a (better) match at greater error levels.
+          break;
+        }
+        last_rd = rd;
+      }
+      return best_loc;
+    }
+
+    /**
+     * Compute and return the score for a match with e errors and x location.
+     * @param e Number of errors in match.
+     * @param x Location of match.
+     * @param loc Expected location of match.
+     * @param pattern Pattern being sought.
+     * @return Overall score for match (0.0 = good, 1.0 = bad).
+     */
+    private double match_bitapScore(int e, int x, int loc, string pattern) {
+      float accuracy = (float)e / pattern.Length;
+      int proximity = Math.Abs(loc - x);
+      if (Match_Distance == 0) {
+        // Dodge divide by zero error.
+        return proximity == 0 ? accuracy : 1.0;
+      }
+      return accuracy + (proximity / (float) Match_Distance);
+    }
+
+    /**
+     * Initialise the alphabet for the Bitap algorithm.
+     * @param pattern The text to encode.
+     * @return Hash of character locations.
+     */
+    protected Dictionary<char, int> match_alphabet(string pattern) {
+      Dictionary<char, int> s = new Dictionary<char, int>();
+      char[] char_pattern = pattern.ToCharArray();
+      foreach (char c in char_pattern) {
+        if (!s.ContainsKey(c)) {
+          s.Add(c, 0);
+        }
+      }
+      int i = 0;
+      foreach (char c in char_pattern) {
+        int value = s[c] | (1 << (pattern.Length - i - 1));
+        s[c] = value;
+        i++;
+      }
+      return s;
+    }
+
+
+    //  PATCH FUNCTIONS
+
+
+    /**
+     * Increase the context until it is unique,
+     * but don't let the pattern expand beyond Match_MaxBits.
+     * @param patch The patch to grow.
+     * @param text Source text.
+     */
+    protected void patch_addContext(Patch patch, string text) {
+      if (text.Length == 0) {
+        return;
+      }
+      string pattern = text.Substring(patch.start2, patch.length1);
+      int padding = 0;
+
+      // Look for the first and last matches of pattern in text.  If two
+      // different matches are found, increase the pattern length.
+      while (text.IndexOf(pattern, StringComparison.Ordinal)
+          != text.LastIndexOf(pattern, StringComparison.Ordinal)
+          && pattern.Length < Match_MaxBits - Patch_Margin - Patch_Margin) {
+        padding += Patch_Margin;
+        pattern = text.JavaSubstring(Math.Max(0, patch.start2 - padding),
+            Math.Min(text.Length, patch.start2 + patch.length1 + padding));
+      }
+      // Add one chunk for good luck.
+      padding += Patch_Margin;
+
+      // Add the prefix.
+      string prefix = text.JavaSubstring(Math.Max(0, patch.start2 - padding),
+        patch.start2);
+      if (prefix.Length != 0) {
+        patch.diffs.Insert(0, new Diff(Operation.EQUAL, prefix));
+      }
+      // Add the suffix.
+      string suffix = text.JavaSubstring(patch.start2 + patch.length1,
+          Math.Min(text.Length, patch.start2 + patch.length1 + padding));
+      if (suffix.Length != 0) {
+        patch.diffs.Add(new Diff(Operation.EQUAL, suffix));
+      }
+
+      // Roll back the start points.
+      patch.start1 -= prefix.Length;
+      patch.start2 -= prefix.Length;
+      // Extend the lengths.
+      patch.length1 += prefix.Length + suffix.Length;
+      patch.length2 += prefix.Length + suffix.Length;
+    }
+
+    /**
+     * Compute a list of patches to turn text1 into text2.
+     * A set of diffs will be computed.
+     * @param text1 Old text.
+     * @param text2 New text.
+     * @return List of Patch objects.
+     */
+    public List<Patch> patch_make(string text1, string text2) {
+      // Check for null inputs not needed since null can't be passed in C#.
+      // No diffs provided, comAdde our own.
+      List<Diff> diffs = diff_main(text1, text2, true);
+      if (diffs.Count > 2) {
+        diff_cleanupSemantic(diffs);
+        diff_cleanupEfficiency(diffs);
+      }
+      return patch_make(text1, diffs);
+    }
+
+    /**
+     * Compute a list of patches to turn text1 into text2.
+     * text1 will be derived from the provided diffs.
+     * @param diffs Array of Diff objects for text1 to text2.
+     * @return List of Patch objects.
+     */
+    public List<Patch> patch_make(List<Diff> diffs) {
+      // Check for null inputs not needed since null can't be passed in C#.
+      // No origin string provided, comAdde our own.
+      string text1 = diff_text1(diffs);
+      return patch_make(text1, diffs);
+    }
+
+    /**
+     * Compute a list of patches to turn text1 into text2.
+     * text2 is ignored, diffs are the delta between text1 and text2.
+     * @param text1 Old text
+     * @param text2 Ignored.
+     * @param diffs Array of Diff objects for text1 to text2.
+     * @return List of Patch objects.
+     * @deprecated Prefer patch_make(string text1, List<Diff> diffs).
+     */
+    public List<Patch> patch_make(string text1, string text2,
+        List<Diff> diffs) {
+      return patch_make(text1, diffs);
+    }
+
+    /**
+     * Compute a list of patches to turn text1 into text2.
+     * text2 is not provided, diffs are the delta between text1 and text2.
+     * @param text1 Old text.
+     * @param diffs Array of Diff objects for text1 to text2.
+     * @return List of Patch objects.
+     */
+    public List<Patch> patch_make(string text1, List<Diff> diffs) {
+      // Check for null inputs not needed since null can't be passed in C#.
+      List<Patch> patches = new List<Patch>();
+      if (diffs.Count == 0) {
+        return patches;  // Get rid of the null case.
+      }
+      Patch patch = new Patch();
+      int char_count1 = 0;  // Number of characters into the text1 string.
+      int char_count2 = 0;  // Number of characters into the text2 string.
+      // Start with text1 (prepatch_text) and apply the diffs until we arrive at
+      // text2 (postpatch_text). We recreate the patches one by one to determine
+      // context info.
+      string prepatch_text = text1;
+      string postpatch_text = text1;
+      foreach (Diff aDiff in diffs) {
+        if (patch.diffs.Count == 0 && aDiff.operation != Operation.EQUAL) {
+          // A new patch starts here.
+          patch.start1 = char_count1;
+          patch.start2 = char_count2;
+        }
+
+        switch (aDiff.operation) {
+          case Operation.INSERT:
+            patch.diffs.Add(aDiff);
+            patch.length2 += aDiff.text.Length;
+            postpatch_text = postpatch_text.Insert(char_count2, aDiff.text);
+            break;
+          case Operation.DELETE:
+            patch.length1 += aDiff.text.Length;
+            patch.diffs.Add(aDiff);
+            postpatch_text = postpatch_text.Remove(char_count2,
+                aDiff.text.Length);
+            break;
+          case Operation.EQUAL:
+            if (aDiff.text.Length <= 2 * Patch_Margin
+                && patch.diffs.Count() != 0 && aDiff != diffs.Last()) {
+              // Small equality inside a patch.
+              patch.diffs.Add(aDiff);
+              patch.length1 += aDiff.text.Length;
+              patch.length2 += aDiff.text.Length;
+            }
+
+            if (aDiff.text.Length >= 2 * Patch_Margin) {
+              // Time for a new patch.
+              if (patch.diffs.Count != 0) {
+                patch_addContext(patch, prepatch_text);
+                patches.Add(patch);
+                patch = new Patch();
+                // Unlike Unidiff, our patch lists have a rolling context.
+                // http://code.google.com/p/google-diff-match-patch/wiki/Unidiff
+                // Update prepatch text & pos to reflect the application of the
+                // just completed patch.
+                prepatch_text = postpatch_text;
+                char_count1 = char_count2;
+              }
+            }
+            break;
+        }
+
+        // Update the current character count.
+        if (aDiff.operation != Operation.INSERT) {
+          char_count1 += aDiff.text.Length;
+        }
+        if (aDiff.operation != Operation.DELETE) {
+          char_count2 += aDiff.text.Length;
+        }
+      }
+      // Pick up the leftover patch if not empty.
+      if (patch.diffs.Count != 0) {
+        patch_addContext(patch, prepatch_text);
+        patches.Add(patch);
+      }
+
+      return patches;
+    }
+
+    /**
+     * Given an array of patches, return another array that is identical.
+     * @param patches Array of Patch objects.
+     * @return Array of Patch objects.
+     */
+    public List<Patch> patch_deepCopy(List<Patch> patches) {
+      List<Patch> patchesCopy = new List<Patch>();
+      foreach (Patch aPatch in patches) {
+        Patch patchCopy = new Patch();
+        foreach (Diff aDiff in aPatch.diffs) {
+          Diff diffCopy = new Diff(aDiff.operation, aDiff.text);
+          patchCopy.diffs.Add(diffCopy);
+        }
+        patchCopy.start1 = aPatch.start1;
+        patchCopy.start2 = aPatch.start2;
+        patchCopy.length1 = aPatch.length1;
+        patchCopy.length2 = aPatch.length2;
+        patchesCopy.Add(patchCopy);
+      }
+      return patchesCopy;
+    }
+
+    /**
+     * Merge a set of patches onto the text.  Return a patched text, as well
+     * as an array of true/false values indicating which patches were applied.
+     * @param patches Array of Patch objects
+     * @param text Old text.
+     * @return Two element Object array, containing the new text and an array of
+     *      bool values.
+     */
+    public Object[] patch_apply(List<Patch> patches, string text) {
+      if (patches.Count == 0) {
+        return new Object[] { text, new bool[0] };
+      }
+
+      // Deep copy the patches so that no changes are made to originals.
+      patches = patch_deepCopy(patches);
+
+      string nullPadding = this.patch_addPadding(patches);
+      text = nullPadding + text + nullPadding;
+      patch_splitMax(patches);
+
+      int x = 0;
+      // delta keeps track of the offset between the expected and actual
+      // location of the previous patch.  If there are patches expected at
+      // positions 10 and 20, but the first patch was found at 12, delta is 2
+      // and the second patch has an effective expected position of 22.
+      int delta = 0;
+      bool[] results = new bool[patches.Count];
+      foreach (Patch aPatch in patches) {
+        int expected_loc = aPatch.start2 + delta;
+        string text1 = diff_text1(aPatch.diffs);
+        int start_loc;
+        int end_loc = -1;
+        if (text1.Length > this.Match_MaxBits) {
+          // patch_splitMax will only provide an oversized pattern
+          // in the case of a monster delete.
+          start_loc = match_main(text,
+              text1.Substring(0, this.Match_MaxBits), expected_loc);
+          if (start_loc != -1) {
+            end_loc = match_main(text,
+                text1.Substring(text1.Length - this.Match_MaxBits),
+                expected_loc + text1.Length - this.Match_MaxBits);
+            if (end_loc == -1 || start_loc >= end_loc) {
+              // Can't find valid trailing context.  Drop this patch.
+              start_loc = -1;
+            }
+          }
+        } else {
+          start_loc = this.match_main(text, text1, expected_loc);
+        }
+        if (start_loc == -1) {
+          // No match found.  :(
+          results[x] = false;
+          // Subtract the delta for this failed patch from subsequent patches.
+          delta -= aPatch.length2 - aPatch.length1;
+        } else {
+          // Found a match.  :)
+          results[x] = true;
+          delta = start_loc - expected_loc;
+          string text2;
+          if (end_loc == -1) {
+            text2 = text.JavaSubstring(start_loc,
+                Math.Min(start_loc + text1.Length, text.Length));
+          } else {
+            text2 = text.JavaSubstring(start_loc,
+                Math.Min(end_loc + this.Match_MaxBits, text.Length));
+          }
+          if (text1 == text2) {
+            // Perfect match, just shove the Replacement text in.
+            text = text.Substring(0, start_loc) + diff_text2(aPatch.diffs)
+                + text.Substring(start_loc + text1.Length);
+          } else {
+            // Imperfect match.  Run a diff to get a framework of equivalent
+            // indices.
+            List<Diff> diffs = diff_main(text1, text2, false);
+            if (text1.Length > this.Match_MaxBits
+                && this.diff_levenshtein(diffs) / (float) text1.Length
+                > this.Patch_DeleteThreshold) {
+              // The end points match, but the content is unacceptably bad.
+              results[x] = false;
+            } else {
+              diff_cleanupSemanticLossless(diffs);
+              int index1 = 0;
+              foreach (Diff aDiff in aPatch.diffs) {
+                if (aDiff.operation != Operation.EQUAL) {
+                  int index2 = diff_xIndex(diffs, index1);
+                  if (aDiff.operation == Operation.INSERT) {
+                    // Insertion
+                    text = text.Insert(start_loc + index2, aDiff.text);
+                  } else if (aDiff.operation == Operation.DELETE) {
+                    // Deletion
+                    text = text.Remove(start_loc + index2, diff_xIndex(diffs,
+                        index1 + aDiff.text.Length) - index2);
+                  }
+                }
+                if (aDiff.operation != Operation.DELETE) {
+                  index1 += aDiff.text.Length;
+                }
+              }
+            }
+          }
+        }
+        x++;
+      }
+      // Strip the padding off.
+      text = text.Substring(nullPadding.Length, text.Length
+          - 2 * nullPadding.Length);
+      return new Object[] { text, results };
+    }
+
+    /**
+     * Add some padding on text start and end so that edges can match something.
+     * Intended to be called only from within patch_apply.
+     * @param patches Array of Patch objects.
+     * @return The padding string added to each side.
+     */
+    public string patch_addPadding(List<Patch> patches) {
+      short paddingLength = this.Patch_Margin;
+      string nullPadding = string.Empty;
+      for (short x = 1; x <= paddingLength; x++) {
+        nullPadding += (char)x;
+      }
+
+      // Bump all the patches forward.
+      foreach (Patch aPatch in patches) {
+        aPatch.start1 += paddingLength;
+        aPatch.start2 += paddingLength;
+      }
+
+      // Add some padding on start of first diff.
+      Patch patch = patches.First();
+      List<Diff> diffs = patch.diffs;
+      if (diffs.Count == 0 || diffs.First().operation != Operation.EQUAL) {
+        // Add nullPadding equality.
+        diffs.Insert(0, new Diff(Operation.EQUAL, nullPadding));
+        patch.start1 -= paddingLength;  // Should be 0.
+        patch.start2 -= paddingLength;  // Should be 0.
+        patch.length1 += paddingLength;
+        patch.length2 += paddingLength;
+      } else if (paddingLength > diffs.First().text.Length) {
+        // Grow first equality.
+        Diff firstDiff = diffs.First();
+        int extraLength = paddingLength - firstDiff.text.Length;
+        firstDiff.text = nullPadding.Substring(firstDiff.text.Length)
+            + firstDiff.text;
+        patch.start1 -= extraLength;
+        patch.start2 -= extraLength;
+        patch.length1 += extraLength;
+        patch.length2 += extraLength;
+      }
+
+      // Add some padding on end of last diff.
+      patch = patches.Last();
+      diffs = patch.diffs;
+      if (diffs.Count == 0 || diffs.Last().operation != Operation.EQUAL) {
+        // Add nullPadding equality.
+        diffs.Add(new Diff(Operation.EQUAL, nullPadding));
+        patch.length1 += paddingLength;
+        patch.length2 += paddingLength;
+      } else if (paddingLength > diffs.Last().text.Length) {
+        // Grow last equality.
+        Diff lastDiff = diffs.Last();
+        int extraLength = paddingLength - lastDiff.text.Length;
+        lastDiff.text += nullPadding.Substring(0, extraLength);
+        patch.length1 += extraLength;
+        patch.length2 += extraLength;
+      }
+
+      return nullPadding;
+    }
+
+    /**
+     * Look through the patches and break up any which are longer than the
+     * maximum limit of the match algorithm.
+     * Intended to be called only from within patch_apply.
+     * @param patches List of Patch objects.
+     */
+    public void patch_splitMax(List<Patch> patches) {
+      short patch_size = this.Match_MaxBits;
+      for (int x = 0; x < patches.Count; x++) {
+        if (patches[x].length1 <= patch_size) {
+          continue;
+        }
+        Patch bigpatch = patches[x];
+        // Remove the big old patch.
+        patches.Splice(x--, 1);
+        int start1 = bigpatch.start1;
+        int start2 = bigpatch.start2;
+        string precontext = string.Empty;
+        while (bigpatch.diffs.Count != 0) {
+          // Create one of several smaller patches.
+          Patch patch = new Patch();
+          bool empty = true;
+          patch.start1 = start1 - precontext.Length;
+          patch.start2 = start2 - precontext.Length;
+          if (precontext.Length != 0) {
+            patch.length1 = patch.length2 = precontext.Length;
+            patch.diffs.Add(new Diff(Operation.EQUAL, precontext));
+          }
+          while (bigpatch.diffs.Count != 0
+              && patch.length1 < patch_size - this.Patch_Margin) {
+            Operation diff_type = bigpatch.diffs[0].operation;
+            string diff_text = bigpatch.diffs[0].text;
+            if (diff_type == Operation.INSERT) {
+              // Insertions are harmless.
+              patch.length2 += diff_text.Length;
+              start2 += diff_text.Length;
+              patch.diffs.Add(bigpatch.diffs.First());
+              bigpatch.diffs.RemoveAt(0);
+              empty = false;
+            } else if (diff_type == Operation.DELETE && patch.diffs.Count == 1
+                && patch.diffs.First().operation == Operation.EQUAL
+                && diff_text.Length > 2 * patch_size) {
+              // This is a large deletion.  Let it pass in one chunk.
+              patch.length1 += diff_text.Length;
+              start1 += diff_text.Length;
+              empty = false;
+              patch.diffs.Add(new Diff(diff_type, diff_text));
+              bigpatch.diffs.RemoveAt(0);
+            } else {
+              // Deletion or equality.  Only take as much as we can stomach.
+              diff_text = diff_text.Substring(0, Math.Min(diff_text.Length,
+                  patch_size - patch.length1 - Patch_Margin));
+              patch.length1 += diff_text.Length;
+              start1 += diff_text.Length;
+              if (diff_type == Operation.EQUAL) {
+                patch.length2 += diff_text.Length;
+                start2 += diff_text.Length;
+              } else {
+                empty = false;
+              }
+              patch.diffs.Add(new Diff(diff_type, diff_text));
+              if (diff_text == bigpatch.diffs[0].text) {
+                bigpatch.diffs.RemoveAt(0);
+              } else {
+                bigpatch.diffs[0].text =
+                    bigpatch.diffs[0].text.Substring(diff_text.Length);
+              }
+            }
+          }
+          // Compute the head context for the next patch.
+          precontext = this.diff_text2(patch.diffs);
+          precontext = precontext.Substring(Math.Max(0,
+              precontext.Length - this.Patch_Margin));
+
+          string postcontext = null;
+          // Append the end context for this patch.
+          if (diff_text1(bigpatch.diffs).Length > Patch_Margin) {
+            postcontext = diff_text1(bigpatch.diffs)
+                .Substring(0, Patch_Margin);
+          } else {
+            postcontext = diff_text1(bigpatch.diffs);
+          }
+
+          if (postcontext.Length != 0) {
+            patch.length1 += postcontext.Length;
+            patch.length2 += postcontext.Length;
+            if (patch.diffs.Count != 0
+                && patch.diffs[patch.diffs.Count - 1].operation
+                == Operation.EQUAL) {
+              patch.diffs[patch.diffs.Count - 1].text += postcontext;
+            } else {
+              patch.diffs.Add(new Diff(Operation.EQUAL, postcontext));
+            }
+          }
+          if (!empty) {
+            patches.Splice(++x, 0, patch);
+          }
+        }
+      }
+    }
+
+    /**
+     * Take a list of patches and return a textual representation.
+     * @param patches List of Patch objects.
+     * @return Text representation of patches.
+     */
+    public string patch_toText(List<Patch> patches) {
+      StringBuilder text = new StringBuilder();
+      foreach (Patch aPatch in patches) {
+        text.Append(aPatch);
+      }
+      return text.ToString();
+    }
+
+    /**
+     * Parse a textual representation of patches and return a List of Patch
+     * objects.
+     * @param textline Text representation of patches.
+     * @return List of Patch objects.
+     * @throws ArgumentException If invalid input.
+     */
+    public List<Patch> patch_fromText(string textline) {
+      List<Patch> patches = new List<Patch>();
+      if (textline.Length == 0) {
+        return patches;
+      }
+      string[] text = textline.Split('\n');
+      int textPointer = 0;
+      Patch patch;
+      Regex patchHeader
+          = new Regex("^@@ -(\\d+),?(\\d*) \\+(\\d+),?(\\d*) @@$");
+      Match m;
+      char sign;
+      string line;
+      while (textPointer < text.Length) {
+        m = patchHeader.Match(text[textPointer]);
+        if (!m.Success) {
+          throw new ArgumentException("Invalid patch string: "
+              + text[textPointer]);
+        }
+        patch = new Patch();
+        patches.Add(patch);
+        patch.start1 = Convert.ToInt32(m.Groups[1].Value);
+        if (m.Groups[2].Length == 0) {
+          patch.start1--;
+          patch.length1 = 1;
+        } else if (m.Groups[2].Value == "0") {
+          patch.length1 = 0;
+        } else {
+          patch.start1--;
+          patch.length1 = Convert.ToInt32(m.Groups[2].Value);
+        }
+
+        patch.start2 = Convert.ToInt32(m.Groups[3].Value);
+        if (m.Groups[4].Length == 0) {
+          patch.start2--;
+          patch.length2 = 1;
+        } else if (m.Groups[4].Value == "0") {
+          patch.length2 = 0;
+        } else {
+          patch.start2--;
+          patch.length2 = Convert.ToInt32(m.Groups[4].Value);
+        }
+        textPointer++;
+
+        while (textPointer < text.Length) {
+          try {
+            sign = text[textPointer][0];
+          } catch (IndexOutOfRangeException) {
+            // Blank line?  Whatever.
+            textPointer++;
+            continue;
+          }
+          line = text[textPointer].Substring(1);
+          line = line.Replace("+", "%2b");
+          line = RestSharp.Contrib.HttpUtility.UrlDecode(line, new UTF8Encoding(false, true));
+          if (sign == '-') {
+            // Deletion.
+            patch.diffs.Add(new Diff(Operation.DELETE, line));
+          } else if (sign == '+') {
+            // Insertion.
+            patch.diffs.Add(new Diff(Operation.INSERT, line));
+          } else if (sign == ' ') {
+            // Minor equality.
+            patch.diffs.Add(new Diff(Operation.EQUAL, line));
+          } else if (sign == '@') {
+            // Start of next patch.
+            break;
+          } else {
+            // WTF?
+            throw new ArgumentException(
+                "Invalid patch mode '" + sign + "' in: " + line);
+          }
+          textPointer++;
+        }
+      }
+      return patches;
+    }
+
+    /**
+     * Unescape selected chars for compatability with JavaScript's encodeURI.
+     * In speed critical applications this could be dropped since the
+     * receiving application will certainly decode these fine.
+     * Note that this function is case-sensitive.  Thus "%3F" would not be
+     * unescaped.  But this is ok because it is only called with the output of
+     * HttpUtility.UrlEncode which returns lowercase hex.
+     *
+     * Example: "%3f" -> "?", "%24" -> "$", etc.
+     *
+     * @param str The string to escape.
+     * @return The escaped string.
+     */
+    public static string unescapeForEncodeUriCompatability(string str) {
+      return str.Replace("%21", "!").Replace("%7e", "~")
+          .Replace("%27", "'").Replace("%28", "(").Replace("%29", ")")
+          .Replace("%3b", ";").Replace("%2f", "/").Replace("%3f", "?")
+          .Replace("%3a", ":").Replace("%40", "@").Replace("%26", "&")
+          .Replace("%3d", "=").Replace("%2b", "+").Replace("%24", "$")
+          .Replace("%2c", ",").Replace("%23", "#");
+    }
+  }
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatch.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatch.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5e9237b9e9c254b1e92a4aa1afa734b0
+timeCreated: 1497582889
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatchTest.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatchTest.cs
@@ -1,0 +1,1182 @@
+﻿/*
+ * Copyright 2008 Google Inc. All Rights Reserved.
+ * Author: fraser@google.com (Neil Fraser)
+ * Author: anteru@developer.shelter13.net (Matthaeus G. Chajdas)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Diff Match and Patch -- Test Harness
+ * http://code.google.com/p/google-diff-match-patch/
+ */
+
+using RedBlueGames.BulkRename.Dependencies.DiffMatchPatch;
+using System.Collections.Generic;
+using System;
+using System.Text;
+using NUnit.Framework;
+
+namespace RedBlueGames.BulkRename.Dependencies.DiffMatchPatch.nicTest {
+  [TestFixture()]
+  public class diff_match_patchTest : diff_match_patch {
+    [Test()]
+    public void diff_commonPrefixTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Detect any common suffix.
+      // Null case.
+      Assert.AreEqual(0, dmp.diff_commonPrefix("abc", "xyz"));
+
+      // Non-null case.
+      Assert.AreEqual(4, dmp.diff_commonPrefix("1234abcdef", "1234xyz"));
+
+      // Whole case.
+      Assert.AreEqual(4, dmp.diff_commonPrefix("1234", "1234xyz"));
+    }
+
+    [Test()]
+    public void diff_commonSuffixTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Detect any common suffix.
+      // Null case.
+      Assert.AreEqual(0, dmp.diff_commonSuffix("abc", "xyz"));
+
+      // Non-null case.
+      Assert.AreEqual(4, dmp.diff_commonSuffix("abcdef1234", "xyz1234"));
+
+      // Whole case.
+      Assert.AreEqual(4, dmp.diff_commonSuffix("1234", "xyz1234"));
+    }
+
+    [Test()]
+    public void diff_commonOverlapTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Detect any suffix/prefix overlap.
+      // Null case.
+      Assert.AreEqual(0, dmp.diff_commonOverlap("", "abcd"));
+
+      // Whole case.
+      Assert.AreEqual(3, dmp.diff_commonOverlap("abc", "abcd"));
+
+      // No overlap.
+      Assert.AreEqual(0, dmp.diff_commonOverlap("123456", "abcd"));
+
+      // Overlap.
+      Assert.AreEqual(3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
+
+      // Unicode.
+      // Some overly clever languages (C#) may treat ligatures as equal to their
+      // component letters.  E.g. U+FB01 == 'fi'
+      Assert.AreEqual(0, dmp.diff_commonOverlap("fi", "\ufb01i"));
+    }
+
+    [Test()]
+    public void diff_halfmatchTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      dmp.Diff_Timeout = 1;
+      // No match.
+      Assert.IsNull(dmp.diff_halfMatch("1234567890", "abcdef"));
+
+      Assert.IsNull(dmp.diff_halfMatch("12345", "23"));
+
+      // Single Match.
+      CollectionAssert.AreEqual(new string[] { "12", "90", "a", "z", "345678" }, dmp.diff_halfMatch("1234567890", "a345678z"));
+
+      CollectionAssert.AreEqual(new string[] { "a", "z", "12", "90", "345678" }, dmp.diff_halfMatch("a345678z", "1234567890"));
+
+      CollectionAssert.AreEqual(new string[] { "abc", "z", "1234", "0", "56789" }, dmp.diff_halfMatch("abc56789z", "1234567890"));
+
+      CollectionAssert.AreEqual(new string[] { "a", "xyz", "1", "7890", "23456" }, dmp.diff_halfMatch("a23456xyz", "1234567890"));
+
+      // Multiple Matches.
+      CollectionAssert.AreEqual(new string[] { "12123", "123121", "a", "z", "1234123451234" }, dmp.diff_halfMatch("121231234123451234123121", "a1234123451234z"));
+
+      CollectionAssert.AreEqual(new string[] { "", "-=-=-=-=-=", "x", "", "x-=-=-=-=-=-=-=" }, dmp.diff_halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="));
+
+      CollectionAssert.AreEqual(new string[] { "-=-=-=-=-=", "", "", "y", "-=-=-=-=-=-=-=y" }, dmp.diff_halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"));
+
+      // Non-optimal halfmatch.
+      // Optimal diff would be -q+x=H-i+e=lloHe+Hu=llo-Hew+y not -qHillo+x=HelloHe-w+Hulloy
+      CollectionAssert.AreEqual(new string[] { "qHillo", "w", "x", "Hulloy", "HelloHe" }, dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+
+      // Optimal no halfmatch.
+      dmp.Diff_Timeout = 0;
+      Assert.IsNull(dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+    }
+
+    [Test()]
+    public void diff_linesToCharsTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Convert lines down to characters.
+      List<string> tmpVector = new List<string>();
+      tmpVector.Add("");
+      tmpVector.Add("alpha\n");
+      tmpVector.Add("beta\n");
+      Object[] result = dmp.diff_linesToChars("alpha\nbeta\nalpha\n", "beta\nalpha\nbeta\n");
+      Assert.AreEqual("\u0001\u0002\u0001", result[0]);
+      Assert.AreEqual("\u0002\u0001\u0002", result[1]);
+      CollectionAssert.AreEqual(tmpVector, (List<string>)result[2]);
+
+      tmpVector.Clear();
+      tmpVector.Add("");
+      tmpVector.Add("alpha\r\n");
+      tmpVector.Add("beta\r\n");
+      tmpVector.Add("\r\n");
+      result = dmp.diff_linesToChars("", "alpha\r\nbeta\r\n\r\n\r\n");
+      Assert.AreEqual("", result[0]);
+      Assert.AreEqual("\u0001\u0002\u0003\u0003", result[1]);
+      CollectionAssert.AreEqual(tmpVector, (List<string>)result[2]);
+
+      tmpVector.Clear();
+      tmpVector.Add("");
+      tmpVector.Add("a");
+      tmpVector.Add("b");
+      result = dmp.diff_linesToChars("a", "b");
+      Assert.AreEqual("\u0001", result[0]);
+      Assert.AreEqual("\u0002", result[1]);
+      CollectionAssert.AreEqual(tmpVector, (List<string>)result[2]);
+
+      // More than 256 to reveal any 8-bit limitations.
+      int n = 300;
+      tmpVector.Clear();
+      StringBuilder lineList = new StringBuilder();
+      StringBuilder charList = new StringBuilder();
+      for (int x = 1; x < n + 1; x++) {
+        tmpVector.Add(x + "\n");
+        lineList.Append(x + "\n");
+        charList.Append(Convert.ToChar(x));
+      }
+      Assert.AreEqual(n, tmpVector.Count);
+      string lines = lineList.ToString();
+      string chars = charList.ToString();
+      Assert.AreEqual(n, chars.Length);
+      tmpVector.Insert(0, "");
+      result = dmp.diff_linesToChars(lines, "");
+      Assert.AreEqual(chars, result[0]);
+      Assert.AreEqual("", result[1]);
+      CollectionAssert.AreEqual(tmpVector, (List<string>)result[2]);
+    }
+
+    [Test()]
+    public void diff_charsToLinesTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Convert chars up to lines.
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "\u0001\u0002\u0001"),
+          new Diff(Operation.INSERT, "\u0002\u0001\u0002")};
+      List<string> tmpVector = new List<string>();
+      tmpVector.Add("");
+      tmpVector.Add("alpha\n");
+      tmpVector.Add("beta\n");
+      dmp.diff_charsToLines(diffs, tmpVector);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "alpha\nbeta\nalpha\n"),
+          new Diff(Operation.INSERT, "beta\nalpha\nbeta\n")}, diffs);
+
+      // More than 256 to reveal any 8-bit limitations.
+      int n = 300;
+      tmpVector.Clear();
+      StringBuilder lineList = new StringBuilder();
+      StringBuilder charList = new StringBuilder();
+      for (int x = 1; x < n + 1; x++) {
+        tmpVector.Add(x + "\n");
+        lineList.Append(x + "\n");
+        charList.Append(Convert.ToChar (x));
+      }
+      Assert.AreEqual(n, tmpVector.Count);
+      string lines = lineList.ToString();
+      string chars = charList.ToString();
+      Assert.AreEqual(n, chars.Length);
+      tmpVector.Insert(0, "");
+      diffs = new List<Diff> {new Diff(Operation.DELETE, chars)};
+      dmp.diff_charsToLines(diffs, tmpVector);
+      CollectionAssert.AreEqual(new List<Diff>
+          {new Diff(Operation.DELETE, lines)}, diffs);
+    }
+
+    [Test()]
+    public void diff_cleanupMergeTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Cleanup a messy diff.
+      // Null case.
+      List<Diff> diffs = new List<Diff>();
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff>(), diffs);
+
+      // No change case.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "b"), new Diff(Operation.INSERT, "c")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "b"), new Diff(Operation.INSERT, "c")}, diffs);
+
+      // Merge equalities.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.EQUAL, "b"), new Diff(Operation.EQUAL, "c")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "abc")}, diffs);
+
+      // Merge deletions.
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "a"), new Diff(Operation.DELETE, "b"), new Diff(Operation.DELETE, "c")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.DELETE, "abc")}, diffs);
+
+      // Merge insertions.
+      diffs = new List<Diff> {new Diff(Operation.INSERT, "a"), new Diff(Operation.INSERT, "b"), new Diff(Operation.INSERT, "c")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.INSERT, "abc")}, diffs);
+
+      // Merge interweave.
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "a"), new Diff(Operation.INSERT, "b"), new Diff(Operation.DELETE, "c"), new Diff(Operation.INSERT, "d"), new Diff(Operation.EQUAL, "e"), new Diff(Operation.EQUAL, "f")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.DELETE, "ac"), new Diff(Operation.INSERT, "bd"), new Diff(Operation.EQUAL, "ef")}, diffs);
+
+      // Prefix and suffix detection.
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "a"), new Diff(Operation.INSERT, "abc"), new Diff(Operation.DELETE, "dc")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "d"), new Diff(Operation.INSERT, "b"), new Diff(Operation.EQUAL, "c")}, diffs);
+
+      // Prefix and suffix detection with equalities.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "x"), new Diff(Operation.DELETE, "a"), new Diff(Operation.INSERT, "abc"), new Diff(Operation.DELETE, "dc"), new Diff(Operation.EQUAL, "y")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "xa"), new Diff(Operation.DELETE, "d"), new Diff(Operation.INSERT, "b"), new Diff(Operation.EQUAL, "cy")}, diffs);
+
+      // Slide edit left.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.INSERT, "ba"), new Diff(Operation.EQUAL, "c")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.INSERT, "ab"), new Diff(Operation.EQUAL, "ac")}, diffs);
+
+      // Slide edit right.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "c"), new Diff(Operation.INSERT, "ab"), new Diff(Operation.EQUAL, "a")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "ca"), new Diff(Operation.INSERT, "ba")}, diffs);
+
+      // Slide edit left recursive.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "b"), new Diff(Operation.EQUAL, "c"), new Diff(Operation.DELETE, "ac"), new Diff(Operation.EQUAL, "x")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.DELETE, "abc"), new Diff(Operation.EQUAL, "acx")}, diffs);
+
+      // Slide edit right recursive.
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "x"), new Diff(Operation.DELETE, "ca"), new Diff(Operation.EQUAL, "c"), new Diff(Operation.DELETE, "b"), new Diff(Operation.EQUAL, "a")};
+      dmp.diff_cleanupMerge(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {new Diff(Operation.EQUAL, "xca"), new Diff(Operation.DELETE, "cba")}, diffs);
+    }
+
+    [Test()]
+    public void diff_cleanupSemanticLosslessTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Slide diffs to match logical boundaries.
+      // Null case.
+      List<Diff> diffs = new List<Diff>();
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff>(), diffs);
+
+      // Blank lines.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "AAA\r\n\r\nBBB"),
+          new Diff(Operation.INSERT, "\r\nDDD\r\n\r\nBBB"),
+          new Diff(Operation.EQUAL, "\r\nEEE")
+      };
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "AAA\r\n\r\n"),
+          new Diff(Operation.INSERT, "BBB\r\nDDD\r\n\r\n"),
+          new Diff(Operation.EQUAL, "BBB\r\nEEE")}, diffs);
+
+      // Line boundaries.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "AAA\r\nBBB"),
+          new Diff(Operation.INSERT, " DDD\r\nBBB"),
+          new Diff(Operation.EQUAL, " EEE")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "AAA\r\n"),
+          new Diff(Operation.INSERT, "BBB DDD\r\n"),
+          new Diff(Operation.EQUAL, "BBB EEE")}, diffs);
+
+      // Word boundaries.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "The c"),
+          new Diff(Operation.INSERT, "ow and the c"),
+          new Diff(Operation.EQUAL, "at.")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "The "),
+          new Diff(Operation.INSERT, "cow and the "),
+          new Diff(Operation.EQUAL, "cat.")}, diffs);
+
+      // Alphanumeric boundaries.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "The-c"),
+          new Diff(Operation.INSERT, "ow-and-the-c"),
+          new Diff(Operation.EQUAL, "at.")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "The-"),
+          new Diff(Operation.INSERT, "cow-and-the-"),
+          new Diff(Operation.EQUAL, "cat.")}, diffs);
+
+      // Hitting the start.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "a"),
+          new Diff(Operation.DELETE, "a"),
+          new Diff(Operation.EQUAL, "ax")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "a"),
+          new Diff(Operation.EQUAL, "aax")}, diffs);
+
+      // Hitting the end.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "xa"),
+          new Diff(Operation.DELETE, "a"),
+          new Diff(Operation.EQUAL, "a")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "xaa"),
+          new Diff(Operation.DELETE, "a")}, diffs);
+
+      // Sentence boundaries.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "The xxx. The "),
+          new Diff(Operation.INSERT, "zzz. The "),
+          new Diff(Operation.EQUAL, "yyy.")};
+      dmp.diff_cleanupSemanticLossless(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "The xxx."),
+          new Diff(Operation.INSERT, " The zzz."),
+          new Diff(Operation.EQUAL, " The yyy.")}, diffs);
+    }
+
+    [Test()]
+    public void diff_cleanupSemanticTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Cleanup semantically trivial equalities.
+      // Null case.
+      List<Diff> diffs = new List<Diff>();
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff>(), diffs);
+
+      // No elimination #1.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "cd"),
+          new Diff(Operation.EQUAL, "12"),
+          new Diff(Operation.DELETE, "e")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "cd"),
+          new Diff(Operation.EQUAL, "12"),
+          new Diff(Operation.DELETE, "e")}, diffs);
+
+      // No elimination #2.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.INSERT, "ABC"),
+          new Diff(Operation.EQUAL, "1234"),
+          new Diff(Operation.DELETE, "wxyz")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.INSERT, "ABC"),
+          new Diff(Operation.EQUAL, "1234"),
+          new Diff(Operation.DELETE, "wxyz")}, diffs);
+
+      // Simple elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "a"),
+          new Diff(Operation.EQUAL, "b"),
+          new Diff(Operation.DELETE, "c")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.INSERT, "b")}, diffs);
+
+      // Backpass elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.EQUAL, "cd"),
+          new Diff(Operation.DELETE, "e"),
+          new Diff(Operation.EQUAL, "f"),
+          new Diff(Operation.INSERT, "g")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abcdef"),
+          new Diff(Operation.INSERT, "cdfg")}, diffs);
+
+      // Multiple eliminations.
+      diffs = new List<Diff> {
+          new Diff(Operation.INSERT, "1"),
+          new Diff(Operation.EQUAL, "A"),
+          new Diff(Operation.DELETE, "B"),
+          new Diff(Operation.INSERT, "2"),
+          new Diff(Operation.EQUAL, "_"),
+          new Diff(Operation.INSERT, "1"),
+          new Diff(Operation.EQUAL, "A"),
+          new Diff(Operation.DELETE, "B"),
+          new Diff(Operation.INSERT, "2")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "AB_AB"),
+          new Diff(Operation.INSERT, "1A2_1A2")}, diffs);
+
+      // Word boundaries.
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "The c"),
+          new Diff(Operation.DELETE, "ow and the c"),
+          new Diff(Operation.EQUAL, "at.")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.EQUAL, "The "),
+          new Diff(Operation.DELETE, "cow and the "),
+          new Diff(Operation.EQUAL, "cat.")}, diffs);
+
+      // No overlap elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abcxx"),
+          new Diff(Operation.INSERT, "xxdef")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abcxx"),
+          new Diff(Operation.INSERT, "xxdef")}, diffs);
+
+      // Overlap elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abcxxx"),
+          new Diff(Operation.INSERT, "xxxdef")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.EQUAL, "xxx"),
+          new Diff(Operation.INSERT, "def")}, diffs);
+
+      // Reverse overlap elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "xxxabc"),
+          new Diff(Operation.INSERT, "defxxx")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.INSERT, "def"),
+          new Diff(Operation.EQUAL, "xxx"),
+          new Diff(Operation.DELETE, "abc")}, diffs);
+
+      // Two overlap eliminations.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abcd1212"),
+          new Diff(Operation.INSERT, "1212efghi"),
+          new Diff(Operation.EQUAL, "----"),
+          new Diff(Operation.DELETE, "A3"),
+          new Diff(Operation.INSERT, "3BC")};
+      dmp.diff_cleanupSemantic(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abcd"),
+          new Diff(Operation.EQUAL, "1212"),
+          new Diff(Operation.INSERT, "efghi"),
+          new Diff(Operation.EQUAL, "----"),
+          new Diff(Operation.DELETE, "A"),
+          new Diff(Operation.EQUAL, "3"),
+          new Diff(Operation.INSERT, "BC")}, diffs);
+    }
+
+    [Test()]
+    public void diff_cleanupEfficiencyTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Cleanup operationally trivial equalities.
+      dmp.Diff_EditCost = 4;
+      // Null case.
+      List<Diff> diffs = new List<Diff> ();
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff>(), diffs);
+
+      // No elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "wxyz"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "34")};
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "wxyz"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "34")}, diffs);
+
+      // Four-edit elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "xyz"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "34")};
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abxyzcd"),
+          new Diff(Operation.INSERT, "12xyz34")}, diffs);
+
+      // Three-edit elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "x"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "34")};
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "xcd"),
+          new Diff(Operation.INSERT, "12x34")}, diffs);
+
+      // Backpass elimination.
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "xy"),
+          new Diff(Operation.INSERT, "34"),
+          new Diff(Operation.EQUAL, "z"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "56")};
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abxyzcd"),
+          new Diff(Operation.INSERT, "12xy34z56")}, diffs);
+
+      // High cost elimination.
+      dmp.Diff_EditCost = 5;
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "ab"),
+          new Diff(Operation.INSERT, "12"),
+          new Diff(Operation.EQUAL, "wxyz"),
+          new Diff(Operation.DELETE, "cd"),
+          new Diff(Operation.INSERT, "34")};
+      dmp.diff_cleanupEfficiency(diffs);
+      CollectionAssert.AreEqual(new List<Diff> {
+          new Diff(Operation.DELETE, "abwxyzcd"),
+          new Diff(Operation.INSERT, "12wxyz34")}, diffs);
+      dmp.Diff_EditCost = 4;
+    }
+
+    [Test()]
+    public void diff_prettyHtmlTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Pretty print.
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "a\n"),
+          new Diff(Operation.DELETE, "<B>b</B>"),
+          new Diff(Operation.INSERT, "c&d")};
+      Assert.AreEqual("<span>a&para;<br></span><del style=\"background:#ffe6e6;\">&lt;B&gt;b&lt;/B&gt;</del><ins style=\"background:#e6ffe6;\">c&amp;d</ins>",
+          dmp.diff_prettyHtml(diffs));
+    }
+
+    [Test()]
+    public void diff_textTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Compute the source and destination texts.
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "jump"),
+          new Diff(Operation.DELETE, "s"),
+          new Diff(Operation.INSERT, "ed"),
+          new Diff(Operation.EQUAL, " over "),
+          new Diff(Operation.DELETE, "the"),
+          new Diff(Operation.INSERT, "a"),
+          new Diff(Operation.EQUAL, " lazy")};
+      Assert.AreEqual("jumps over the lazy", dmp.diff_text1(diffs));
+
+      Assert.AreEqual("jumped over a lazy", dmp.diff_text2(diffs));
+    }
+
+    [Test()]
+    public void diff_deltaTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Convert a diff into delta string.
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "jump"),
+          new Diff(Operation.DELETE, "s"),
+          new Diff(Operation.INSERT, "ed"),
+          new Diff(Operation.EQUAL, " over "),
+          new Diff(Operation.DELETE, "the"),
+          new Diff(Operation.INSERT, "a"),
+          new Diff(Operation.EQUAL, " lazy"),
+          new Diff(Operation.INSERT, "old dog")};
+      string text1 = dmp.diff_text1(diffs);
+      Assert.AreEqual("jumps over the lazy", text1);
+
+      string delta = dmp.diff_toDelta(diffs);
+      Assert.AreEqual("=4\t-1\t+ed\t=6\t-3\t+a\t=5\t+old dog", delta);
+
+      // Convert delta string into a diff.
+      CollectionAssert.AreEqual(diffs, dmp.diff_fromDelta(text1, delta));
+
+      // Generates error (19 < 20).
+      try {
+        dmp.diff_fromDelta(text1 + "x", delta);
+        Assert.Fail("diff_fromDelta: Too long.");
+      } catch (ArgumentException) {
+        // Exception expected.
+      }
+
+      // Generates error (19 > 18).
+      try {
+        dmp.diff_fromDelta(text1.Substring(1), delta);
+        Assert.Fail("diff_fromDelta: Too short.");
+      } catch (ArgumentException) {
+        // Exception expected.
+      }
+
+      // Generates error (%c3%xy invalid Unicode).
+      try {
+        dmp.diff_fromDelta("", "+%c3%xy");
+        Assert.Fail("diff_fromDelta: Invalid character.");
+      } catch (ArgumentException) {
+        // Exception expected.
+      }
+
+      // Test deltas with special characters.
+      char zero = (char)0;
+      char one = (char)1;
+      char two = (char)2;
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "\u0680 " + zero + " \t %"),
+          new Diff(Operation.DELETE, "\u0681 " + one + " \n ^"),
+          new Diff(Operation.INSERT, "\u0682 " + two + " \\ |")};
+      text1 = dmp.diff_text1(diffs);
+      Assert.AreEqual("\u0680 " + zero + " \t %\u0681 " + one + " \n ^", text1);
+
+      delta = dmp.diff_toDelta(diffs);
+      // Lowercase, due to UrlEncode uses lower.
+      Assert.AreEqual("=7\t-7\t+%da%82 %02 %5c %7c", delta, "diff_toDelta: Unicode.");
+
+      CollectionAssert.AreEqual(diffs, dmp.diff_fromDelta(text1, delta), "diff_fromDelta: Unicode.");
+
+      // Verify pool of unchanged characters.
+      diffs = new List<Diff> {
+          new Diff(Operation.INSERT, "A-Z a-z 0-9 - _ . ! ~ * ' ( ) ; / ? : @ & = + $ , # ")};
+      string text2 = dmp.diff_text2(diffs);
+      Assert.AreEqual("A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", text2, "diff_text2: Unchanged characters.");
+
+      delta = dmp.diff_toDelta(diffs);
+      Assert.AreEqual("+A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", delta, "diff_toDelta: Unchanged characters.");
+
+      // Convert delta string into a diff.
+      CollectionAssert.AreEqual(diffs, dmp.diff_fromDelta("", delta), "diff_fromDelta: Unchanged characters.");
+    }
+
+    [Test()]
+    public void diff_xIndexTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Translate a location in text1 to text2.
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "a"),
+          new Diff(Operation.INSERT, "1234"),
+          new Diff(Operation.EQUAL, "xyz")};
+      Assert.AreEqual(5, dmp.diff_xIndex(diffs, 2), "diff_xIndex: Translation on equality.");
+
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "a"),
+          new Diff(Operation.DELETE, "1234"),
+          new Diff(Operation.EQUAL, "xyz")};
+      Assert.AreEqual(1, dmp.diff_xIndex(diffs, 3), "diff_xIndex: Translation on deletion.");
+    }
+
+    [Test()]
+    public void diff_levenshteinTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      List<Diff> diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.INSERT, "1234"),
+          new Diff(Operation.EQUAL, "xyz")};
+      Assert.AreEqual(4, dmp.diff_levenshtein(diffs), "diff_levenshtein: Levenshtein with trailing equality.");
+
+      diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "xyz"),
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.INSERT, "1234")};
+      Assert.AreEqual(4, dmp.diff_levenshtein(diffs), "diff_levenshtein: Levenshtein with leading equality.");
+
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "abc"),
+          new Diff(Operation.EQUAL, "xyz"),
+          new Diff(Operation.INSERT, "1234")};
+      Assert.AreEqual(7, dmp.diff_levenshtein(diffs), "diff_levenshtein: Levenshtein with middle equality.");
+    }
+
+    [Test()]
+    public void diff_bisectTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Normal.
+      string a = "cat";
+      string b = "map";
+      // Since the resulting diff hasn't been normalized, it would be ok if
+      // the insertion and deletion pairs are swapped.
+      // If the order changes, tweak this test as required.
+      List<Diff> diffs = new List<Diff> {new Diff(Operation.DELETE, "c"), new Diff(Operation.INSERT, "m"), new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "t"), new Diff(Operation.INSERT, "p")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_bisect(a, b, DateTime.MaxValue));
+
+      // Timeout.
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "cat"), new Diff(Operation.INSERT, "map")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_bisect(a, b, DateTime.MinValue));
+    }
+
+    [Test()]
+    public void diff_mainTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Perform a trivial diff.
+      List<Diff> diffs = new List<Diff> {};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("", "", false), "diff_main: Null case.");
+
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "abc")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("abc", "abc", false), "diff_main: Equality.");
+
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "ab"), new Diff(Operation.INSERT, "123"), new Diff(Operation.EQUAL, "c")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("abc", "ab123c", false), "diff_main: Simple insertion.");
+
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "123"), new Diff(Operation.EQUAL, "bc")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("a123bc", "abc", false), "diff_main: Simple deletion.");
+
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.INSERT, "123"), new Diff(Operation.EQUAL, "b"), new Diff(Operation.INSERT, "456"), new Diff(Operation.EQUAL, "c")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("abc", "a123b456c", false), "diff_main: Two insertions.");
+
+      diffs = new List<Diff> {new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "123"), new Diff(Operation.EQUAL, "b"), new Diff(Operation.DELETE, "456"), new Diff(Operation.EQUAL, "c")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("a123b456c", "abc", false), "diff_main: Two deletions.");
+
+      // Perform a real diff.
+      // Switch off the timeout.
+      dmp.Diff_Timeout = 0;
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "a"), new Diff(Operation.INSERT, "b")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("a", "b", false), "diff_main: Simple case #1.");
+
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "Apple"), new Diff(Operation.INSERT, "Banana"), new Diff(Operation.EQUAL, "s are a"), new Diff(Operation.INSERT, "lso"), new Diff(Operation.EQUAL, " fruit.")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("Apples are a fruit.", "Bananas are also fruit.", false), "diff_main: Simple case #2.");
+
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "a"), new Diff(Operation.INSERT, "\u0680"), new Diff(Operation.EQUAL, "x"), new Diff(Operation.DELETE, "\t"), new Diff(Operation.INSERT, new string (new char[]{(char)0}))};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("ax\t", "\u0680x" + (char)0, false), "diff_main: Simple case #3.");
+
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "1"), new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "y"), new Diff(Operation.EQUAL, "b"), new Diff(Operation.DELETE, "2"), new Diff(Operation.INSERT, "xab")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("1ayb2", "abxab", false), "diff_main: Overlap #1.");
+
+      diffs = new List<Diff> {new Diff(Operation.INSERT, "xaxcx"), new Diff(Operation.EQUAL, "abc"), new Diff(Operation.DELETE, "y")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("abcy", "xaxcxabc", false), "diff_main: Overlap #2.");
+
+      diffs = new List<Diff> {new Diff(Operation.DELETE, "ABCD"), new Diff(Operation.EQUAL, "a"), new Diff(Operation.DELETE, "="), new Diff(Operation.INSERT, "-"), new Diff(Operation.EQUAL, "bcd"), new Diff(Operation.DELETE, "="), new Diff(Operation.INSERT, "-"), new Diff(Operation.EQUAL, "efghijklmnopqrs"), new Diff(Operation.DELETE, "EFGHIJKLMNOefg")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("ABCDa=bcd=efghijklmnopqrsEFGHIJKLMNOefg", "a-bcd-efghijklmnopqrs", false), "diff_main: Overlap #3.");
+
+      diffs = new List<Diff> {new Diff(Operation.INSERT, " "), new Diff(Operation.EQUAL, "a"), new Diff(Operation.INSERT, "nd"), new Diff(Operation.EQUAL, " [[Pennsylvania]]"), new Diff(Operation.DELETE, " and [[New")};
+      CollectionAssert.AreEqual(diffs, dmp.diff_main("a [[Pennsylvania]] and [[New", " and [[Pennsylvania]]", false), "diff_main: Large equality.");
+
+      dmp.Diff_Timeout = 0.1f;  // 100ms
+      string a = "`Twas brillig, and the slithy toves\nDid gyre and gimble in the wabe:\nAll mimsy were the borogoves,\nAnd the mome raths outgrabe.\n";
+      string b = "I am the very model of a modern major general,\nI've information vegetable, animal, and mineral,\nI know the kings of England, and I quote the fights historical,\nFrom Marathon to Waterloo, in order categorical.\n";
+      // Increase the text lengths by 1024 times to ensure a timeout.
+      for (int x = 0; x < 10; x++) {
+        a = a + a;
+        b = b + b;
+      }
+      DateTime startTime = DateTime.Now;
+      dmp.diff_main(a, b);
+      DateTime endTime = DateTime.Now;
+      // Test that we took at least the timeout period.
+      Assert.IsTrue(new TimeSpan(((long)(dmp.Diff_Timeout * 1000)) * 10000) <= endTime - startTime);
+      // Test that we didn't take forever (be forgiving).
+      // Theoretically this test could fail very occasionally if the
+      // OS task swaps or locks up for a second at the wrong moment.
+      Assert.IsTrue(new TimeSpan(((long)(dmp.Diff_Timeout * 1000)) * 10000 * 2) > endTime - startTime);
+      dmp.Diff_Timeout = 0;
+
+      // Test the linemode speedup.
+      // Must be long to pass the 100 char cutoff.
+      a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n";
+      b = "abcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\n";
+      CollectionAssert.AreEqual(dmp.diff_main(a, b, true), dmp.diff_main(a, b, false), "diff_main: Simple line-mode.");
+
+      a = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+      b = "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij";
+      CollectionAssert.AreEqual(dmp.diff_main(a, b, true), dmp.diff_main(a, b, false), "diff_main: Single line-mode.");
+
+      a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n";
+      b = "abcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n";
+      string[] texts_linemode = diff_rebuildtexts(dmp.diff_main(a, b, true));
+      string[] texts_textmode = diff_rebuildtexts(dmp.diff_main(a, b, false));
+      CollectionAssert.AreEqual(texts_textmode, texts_linemode, "diff_main: Overlap line-mode.");
+
+      // Test null inputs -- not needed because nulls can't be passed in C#.
+    }
+
+    [Test()]
+    public void match_alphabetTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Initialise the bitmasks for Bitap.
+      Dictionary<char, int> bitmask = new Dictionary<char, int>();
+      bitmask.Add('a', 4); bitmask.Add('b', 2); bitmask.Add('c', 1);
+      CollectionAssert.AreEqual(bitmask, dmp.match_alphabet("abc"), "match_alphabet: Unique.");
+
+      bitmask.Clear();
+      bitmask.Add('a', 37); bitmask.Add('b', 18); bitmask.Add('c', 8);
+      CollectionAssert.AreEqual(bitmask, dmp.match_alphabet("abcaba"), "match_alphabet: Duplicates.");
+    }
+
+    [Test()]
+    public void match_bitapTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+
+      // Bitap algorithm.
+      dmp.Match_Distance = 100;
+      dmp.Match_Threshold = 0.5f;
+      Assert.AreEqual(5, dmp.match_bitap("abcdefghijk", "fgh", 5), "match_bitap: Exact match #1.");
+
+      Assert.AreEqual(5, dmp.match_bitap("abcdefghijk", "fgh", 0), "match_bitap: Exact match #2.");
+
+      Assert.AreEqual(4, dmp.match_bitap("abcdefghijk", "efxhi", 0), "match_bitap: Fuzzy match #1.");
+
+      Assert.AreEqual(2, dmp.match_bitap("abcdefghijk", "cdefxyhijk", 5), "match_bitap: Fuzzy match #2.");
+
+      Assert.AreEqual(-1, dmp.match_bitap("abcdefghijk", "bxy", 1), "match_bitap: Fuzzy match #3.");
+
+      Assert.AreEqual(2, dmp.match_bitap("123456789xx0", "3456789x0", 2), "match_bitap: Overflow.");
+
+      Assert.AreEqual(0, dmp.match_bitap("abcdef", "xxabc", 4), "match_bitap: Before start match.");
+
+      Assert.AreEqual(3, dmp.match_bitap("abcdef", "defyy", 4), "match_bitap: Beyond end match.");
+
+      Assert.AreEqual(0, dmp.match_bitap("abcdef", "xabcdefy", 0), "match_bitap: Oversized pattern.");
+
+      dmp.Match_Threshold = 0.4f;
+      Assert.AreEqual(4, dmp.match_bitap("abcdefghijk", "efxyhi", 1), "match_bitap: Threshold #1.");
+
+      dmp.Match_Threshold = 0.3f;
+      Assert.AreEqual(-1, dmp.match_bitap("abcdefghijk", "efxyhi", 1), "match_bitap: Threshold #2.");
+
+      dmp.Match_Threshold = 0.0f;
+      Assert.AreEqual(1, dmp.match_bitap("abcdefghijk", "bcdef", 1), "match_bitap: Threshold #3.");
+
+      dmp.Match_Threshold = 0.5f;
+      Assert.AreEqual(0, dmp.match_bitap("abcdexyzabcde", "abccde", 3), "match_bitap: Multiple select #1.");
+
+      Assert.AreEqual(8, dmp.match_bitap("abcdexyzabcde", "abccde", 5), "match_bitap: Multiple select #2.");
+
+      dmp.Match_Distance = 10;  // Strict location.
+      Assert.AreEqual(-1, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24), "match_bitap: Distance test #1.");
+
+      Assert.AreEqual(0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdxxefg", 1), "match_bitap: Distance test #2.");
+
+      dmp.Match_Distance = 1000;  // Loose location.
+      Assert.AreEqual(0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24), "match_bitap: Distance test #3.");
+    }
+
+    [Test()]
+    public void match_mainTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      // Full match.
+      Assert.AreEqual(0, dmp.match_main("abcdef", "abcdef", 1000), "match_main: Equality.");
+
+      Assert.AreEqual(-1, dmp.match_main("", "abcdef", 1), "match_main: Null text.");
+
+      Assert.AreEqual(3, dmp.match_main("abcdef", "", 3), "match_main: Null pattern.");
+
+      Assert.AreEqual(3, dmp.match_main("abcdef", "de", 3), "match_main: Exact match.");
+
+      Assert.AreEqual(3, dmp.match_main("abcdef", "defy", 4), "match_main: Beyond end match.");
+
+      Assert.AreEqual(0, dmp.match_main("abcdef", "abcdefy", 0), "match_main: Oversized pattern.");
+
+      dmp.Match_Threshold = 0.7f;
+      Assert.AreEqual(4, dmp.match_main("I am the very model of a modern major general.", " that berry ", 5), "match_main: Complex match.");
+      dmp.Match_Threshold = 0.5f;
+
+      // Test null inputs -- not needed because nulls can't be passed in C#.
+    }
+
+    [Test()]
+    public void patch_patchObjTest() {
+      // Patch Object.
+      Patch p = new Patch();
+      p.start1 = 20;
+      p.start2 = 21;
+      p.length1 = 18;
+      p.length2 = 17;
+      p.diffs = new List<Diff> {
+          new Diff(Operation.EQUAL, "jump"),
+          new Diff(Operation.DELETE, "s"),
+          new Diff(Operation.INSERT, "ed"),
+          new Diff(Operation.EQUAL, " over "),
+          new Diff(Operation.DELETE, "the"),
+          new Diff(Operation.INSERT, "a"),
+          new Diff(Operation.EQUAL, "\nlaz")};
+      string strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0alaz\n";
+      Assert.AreEqual(strp, p.ToString(), "Patch: toString.");
+    }
+
+    [Test()]
+    public void patch_fromTextTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      Assert.IsTrue(dmp.patch_fromText("").Count == 0, "patch_fromText: #0.");
+
+      string strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0alaz\n";
+      Assert.AreEqual(strp, dmp.patch_fromText(strp)[0].ToString(), "patch_fromText: #1.");
+
+      Assert.AreEqual("@@ -1 +1 @@\n-a\n+b\n", dmp.patch_fromText("@@ -1 +1 @@\n-a\n+b\n")[0].ToString(), "patch_fromText: #2.");
+
+      Assert.AreEqual("@@ -1,3 +0,0 @@\n-abc\n", dmp.patch_fromText("@@ -1,3 +0,0 @@\n-abc\n") [0].ToString(), "patch_fromText: #3.");
+
+      Assert.AreEqual("@@ -0,0 +1,3 @@\n+abc\n", dmp.patch_fromText("@@ -0,0 +1,3 @@\n+abc\n") [0].ToString(), "patch_fromText: #4.");
+
+      // Generates error.
+      try {
+        dmp.patch_fromText("Bad\nPatch\n");
+        Assert.Fail("patch_fromText: #5.");
+      } catch (ArgumentException) {
+        // Exception expected.
+      }
+    }
+
+    [Test()]
+    public void patch_toTextTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      string strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
+      List<Patch> patches;
+      patches = dmp.patch_fromText(strp);
+      string result = dmp.patch_toText(patches);
+      Assert.AreEqual(strp, result);
+
+      strp = "@@ -1,9 +1,9 @@\n-f\n+F\n oo+fooba\n@@ -7,9 +7,9 @@\n obar\n-,\n+.\n  tes\n";
+      patches = dmp.patch_fromText(strp);
+      result = dmp.patch_toText(patches);
+      Assert.AreEqual(strp, result);
+    }
+
+    [Test()]
+    public void patch_addContextTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      dmp.Patch_Margin = 4;
+      Patch p;
+      p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n") [0];
+      dmp.patch_addContext(p, "The quick brown fox jumps over the lazy dog.");
+      Assert.AreEqual("@@ -17,12 +17,18 @@\n fox \n-jump\n+somersault\n s ov\n", p.ToString(), "patch_addContext: Simple case.");
+
+      p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n")[0];
+      dmp.patch_addContext(p, "The quick brown fox jumps.");
+      Assert.AreEqual("@@ -17,10 +17,16 @@\n fox \n-jump\n+somersault\n s.\n", p.ToString(), "patch_addContext: Not enough trailing context.");
+
+      p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n")[0];
+      dmp.patch_addContext(p, "The quick brown fox jumps.");
+      Assert.AreEqual("@@ -1,7 +1,8 @@\n Th\n-e\n+at\n  qui\n", p.ToString(), "patch_addContext: Not enough leading context.");
+
+      p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n")[0];
+      dmp.patch_addContext(p, "The quick brown fox jumps.  The quick brown fox crashes.");
+      Assert.AreEqual("@@ -1,27 +1,28 @@\n Th\n-e\n+at\n  quick brown fox jumps. \n", p.ToString(), "patch_addContext: Ambiguity.");
+    }
+
+    [Test()]
+    public void patch_makeTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      List<Patch> patches;
+      patches = dmp.patch_make("", "");
+      Assert.AreEqual("", dmp.patch_toText(patches), "patch_make: Null case.");
+
+      string text1 = "The quick brown fox jumps over the lazy dog.";
+      string text2 = "That quick brown fox jumped over a lazy dog.";
+      string expectedPatch = "@@ -1,8 +1,7 @@\n Th\n-at\n+e\n  qui\n@@ -21,17 +21,18 @@\n jump\n-ed\n+s\n  over \n-a\n+the\n  laz\n";
+      // The second patch must be "-21,17 +21,18", not "-22,17 +21,18" due to rolling context.
+      patches = dmp.patch_make(text2, text1);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Text2+Text1 inputs.");
+
+      expectedPatch = "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
+      patches = dmp.patch_make(text1, text2);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Text1+Text2 inputs.");
+
+      List<Diff> diffs = dmp.diff_main(text1, text2, false);
+      patches = dmp.patch_make(diffs);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Diff input.");
+
+      patches = dmp.patch_make(text1, diffs);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Text1+Diff inputs.");
+
+      patches = dmp.patch_make(text1, text2, diffs);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Text1+Text2+Diff inputs (deprecated).");
+
+      patches = dmp.patch_make("`1234567890-=[]\\;',./", "~!@#$%^&*()_+{}|:\"<>?");
+      Assert.AreEqual("@@ -1,21 +1,21 @@\n-%601234567890-=%5b%5d%5c;',./\n+~!@#$%25%5e&*()_+%7b%7d%7c:%22%3c%3e?\n",
+          dmp.patch_toText(patches),
+          "patch_toText: Character encoding.");
+
+      diffs = new List<Diff> {
+          new Diff(Operation.DELETE, "`1234567890-=[]\\;',./"),
+          new Diff(Operation.INSERT, "~!@#$%^&*()_+{}|:\"<>?")};
+      CollectionAssert.AreEqual(diffs,
+          dmp.patch_fromText("@@ -1,21 +1,21 @@\n-%601234567890-=%5B%5D%5C;',./\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n") [0].diffs,
+          "patch_fromText: Character decoding.");
+
+      text1 = "";
+      for (int x = 0; x < 100; x++) {
+        text1 += "abcdef";
+      }
+      text2 = text1 + "123";
+      expectedPatch = "@@ -573,28 +573,31 @@\n cdefabcdefabcdefabcdefabcdef\n+123\n";
+      patches = dmp.patch_make(text1, text2);
+      Assert.AreEqual(expectedPatch, dmp.patch_toText(patches), "patch_make: Long string with repeats.");
+
+      // Test null inputs -- not needed because nulls can't be passed in C#.
+    }
+
+    [Test()]
+    public void patch_splitMaxTest() {
+      // Assumes that Match_MaxBits is 32.
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      List<Patch> patches;
+
+      patches = dmp.patch_make("abcdefghijklmnopqrstuvwxyz01234567890", "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0");
+      dmp.patch_splitMax(patches);
+      Assert.AreEqual("@@ -1,32 +1,46 @@\n+X\n ab\n+X\n cd\n+X\n ef\n+X\n gh\n+X\n ij\n+X\n kl\n+X\n mn\n+X\n op\n+X\n qr\n+X\n st\n+X\n uv\n+X\n wx\n+X\n yz\n+X\n 012345\n@@ -25,13 +39,18 @@\n zX01\n+X\n 23\n+X\n 45\n+X\n 67\n+X\n 89\n+X\n 0\n", dmp.patch_toText(patches));
+
+      patches = dmp.patch_make("abcdef1234567890123456789012345678901234567890123456789012345678901234567890uvwxyz", "abcdefuvwxyz");
+      string oldToText = dmp.patch_toText(patches);
+      dmp.patch_splitMax(patches);
+      Assert.AreEqual(oldToText, dmp.patch_toText(patches));
+
+      patches = dmp.patch_make("1234567890123456789012345678901234567890123456789012345678901234567890", "abc");
+      dmp.patch_splitMax(patches);
+      Assert.AreEqual("@@ -1,32 +1,4 @@\n-1234567890123456789012345678\n 9012\n@@ -29,32 +1,4 @@\n-9012345678901234567890123456\n 7890\n@@ -57,14 +1,3 @@\n-78901234567890\n+abc\n", dmp.patch_toText(patches));
+
+      patches = dmp.patch_make("abcdefghij , h : 0 , t : 1 abcdefghij , h : 0 , t : 1 abcdefghij , h : 0 , t : 1", "abcdefghij , h : 1 , t : 1 abcdefghij , h : 1 , t : 1 abcdefghij , h : 0 , t : 1");
+      dmp.patch_splitMax(patches);
+      Assert.AreEqual("@@ -2,32 +2,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n@@ -29,32 +29,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n", dmp.patch_toText(patches));
+    }
+
+    [Test()]
+    public void patch_addPaddingTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      List<Patch> patches;
+      patches = dmp.patch_make("", "test");
+      Assert.AreEqual("@@ -0,0 +1,4 @@\n+test\n",
+         dmp.patch_toText(patches),
+         "patch_addPadding: Both edges full.");
+      dmp.patch_addPadding(patches);
+      Assert.AreEqual("@@ -1,8 +1,12 @@\n %01%02%03%04\n+test\n %01%02%03%04\n",
+          dmp.patch_toText(patches),
+          "patch_addPadding: Both edges full.");
+
+      patches = dmp.patch_make("XY", "XtestY");
+      Assert.AreEqual("@@ -1,2 +1,6 @@\n X\n+test\n Y\n",
+          dmp.patch_toText(patches),
+          "patch_addPadding: Both edges partial.");
+      dmp.patch_addPadding(patches);
+      Assert.AreEqual("@@ -2,8 +2,12 @@\n %02%03%04X\n+test\n Y%01%02%03\n",
+          dmp.patch_toText(patches),
+          "patch_addPadding: Both edges partial.");
+
+      patches = dmp.patch_make("XXXXYYYY", "XXXXtestYYYY");
+      Assert.AreEqual("@@ -1,8 +1,12 @@\n XXXX\n+test\n YYYY\n",
+          dmp.patch_toText(patches),
+          "patch_addPadding: Both edges none.");
+      dmp.patch_addPadding(patches);
+      Assert.AreEqual("@@ -5,8 +5,12 @@\n XXXX\n+test\n YYYY\n",
+         dmp.patch_toText(patches),
+         "patch_addPadding: Both edges none.");
+    }
+
+    [Test()]
+    public void patch_applyTest() {
+      diff_match_patchTest dmp = new diff_match_patchTest();
+      dmp.Match_Distance = 1000;
+      dmp.Match_Threshold = 0.5f;
+      dmp.Patch_DeleteThreshold = 0.5f;
+      List<Patch> patches;
+      patches = dmp.patch_make("", "");
+      Object[] results = dmp.patch_apply(patches, "Hello world.");
+      bool[] boolArray = (bool[])results[1];
+      string resultStr = results[0] + "\t" + boolArray.Length;
+      Assert.AreEqual("Hello world.\t0", resultStr, "patch_apply: Null case.");
+
+      patches = dmp.patch_make("The quick brown fox jumps over the lazy dog.", "That quick brown fox jumped over a lazy dog.");
+      results = dmp.patch_apply(patches, "The quick brown fox jumps over the lazy dog.");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("That quick brown fox jumped over a lazy dog.\tTrue\tTrue", resultStr, "patch_apply: Exact match.");
+
+      results = dmp.patch_apply(patches, "The quick red rabbit jumps over the tired tiger.");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("That quick red rabbit jumped over a tired tiger.\tTrue\tTrue", resultStr, "patch_apply: Partial match.");
+
+      results = dmp.patch_apply(patches, "I am the very model of a modern major general.");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("I am the very model of a modern major general.\tFalse\tFalse", resultStr, "patch_apply: Failed match.");
+
+      patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
+      results = dmp.patch_apply(patches, "x123456789012345678901234567890-----++++++++++-----123456789012345678901234567890y");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("xabcy\tTrue\tTrue", resultStr, "patch_apply: Big delete, small change.");
+
+      patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
+      results = dmp.patch_apply(patches, "x12345678901234567890---------------++++++++++---------------12345678901234567890y");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("xabc12345678901234567890---------------++++++++++---------------12345678901234567890y\tFalse\tTrue", resultStr, "patch_apply: Big delete, big change 1.");
+
+      dmp.Patch_DeleteThreshold = 0.6f;
+      patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
+      results = dmp.patch_apply(patches, "x12345678901234567890---------------++++++++++---------------12345678901234567890y");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("xabcy\tTrue\tTrue", resultStr, "patch_apply: Big delete, big change 2.");
+      dmp.Patch_DeleteThreshold = 0.5f;
+
+      dmp.Match_Threshold = 0.0f;
+      dmp.Match_Distance = 0;
+      patches = dmp.patch_make("abcdefghijklmnopqrstuvwxyz--------------------1234567890", "abcXXXXXXXXXXdefghijklmnopqrstuvwxyz--------------------1234567YYYYYYYYYY890");
+      results = dmp.patch_apply(patches, "ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------1234567890");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0] + "\t" + boolArray[1];
+      Assert.AreEqual("ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------1234567YYYYYYYYYY890\tFalse\tTrue", resultStr, "patch_apply: Compensate for failed patch.");
+      dmp.Match_Threshold = 0.5f;
+      dmp.Match_Distance = 1000;
+
+      patches = dmp.patch_make("", "test");
+      string patchStr = dmp.patch_toText(patches);
+      dmp.patch_apply(patches, "");
+      Assert.AreEqual(patchStr, dmp.patch_toText(patches), "patch_apply: No side effects.");
+
+      patches = dmp.patch_make("The quick brown fox jumps over the lazy dog.", "Woof");
+      patchStr = dmp.patch_toText(patches);
+      dmp.patch_apply(patches, "The quick brown fox jumps over the lazy dog.");
+      Assert.AreEqual(patchStr, dmp.patch_toText(patches), "patch_apply: No side effects with major delete.");
+
+      patches = dmp.patch_make("", "test");
+      results = dmp.patch_apply(patches, "");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0];
+      Assert.AreEqual("test\tTrue", resultStr, "patch_apply: Edge exact match.");
+
+      patches = dmp.patch_make("XY", "XtestY");
+      results = dmp.patch_apply(patches, "XY");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0];
+      Assert.AreEqual("XtestY\tTrue", resultStr, "patch_apply: Near edge exact match.");
+
+      patches = dmp.patch_make("y", "y123");
+      results = dmp.patch_apply(patches, "x");
+      boolArray = (bool[])results[1];
+      resultStr = results[0] + "\t" + boolArray[0];
+      Assert.AreEqual("x123\tTrue", resultStr, "patch_apply: Edge partial match.");
+    }
+
+    private static string[] diff_rebuildtexts(List<Diff> diffs) {
+      string[] text = { "", "" };
+      foreach (Diff myDiff in diffs) {
+        if (myDiff.operation != Operation.INSERT) {
+          text[0] += myDiff.text;
+        }
+        if (myDiff.operation != Operation.DELETE) {
+          text[1] += myDiff.text;
+        }
+      }
+      return text;
+    }
+  }
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatchTest.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatchTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4b1232909e1eb41a2b6aabe737eb8bea
+timeCreated: 1497582889
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 182bab78b71704ede8fe617d20a4517f
+folderAsset: yes
+timeCreated: 1497586384
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/Helpers.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/Helpers.cs
@@ -1,0 +1,38 @@
+﻿//
+// System.Web.Util.Helpers
+//
+// Authors:
+//	Marek Habersack (mhabersack@novell.com)
+//
+// (C) 2009 Novell, Inc (http://novell.com)
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Globalization;
+
+namespace RedBlueGames.BulkRename.Dependencies.RestSharp.Contrib
+{
+	class Helpers
+	{
+		public static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
+	}
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/Helpers.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/Helpers.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: adf03b76785194944b3978185b0d74be
+timeCreated: 1497586508
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HtmlEncoder.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HtmlEncoder.cs
@@ -1,0 +1,918 @@
+﻿//
+// Authors:
+//   Patrik Torstensson (Patrik.Torstensson@labs2.com)
+//   Wictor WilÃ©n (decode/encode functions) (wictor@ibizkit.se)
+//   Tim Coleman (tim@timcoleman.com)
+//   Gonzalo Paniagua Javier (gonzalo@ximian.com)
+
+//   Marek Habersack <mhabersack@novell.com>
+//
+// (C) 2005-2010 Novell, Inc (http://novell.com/)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Text;
+#if NET_4_0
+using System.Web.Configuration;
+#endif
+
+namespace RedBlueGames.BulkRename.Dependencies.RestSharp.Contrib
+{
+#if NET_4_0
+	public
+#endif
+	class HttpEncoder
+	{
+		static char[] hexChars = "0123456789abcdef".ToCharArray();
+		static object entitiesLock = new object();
+		static SortedDictionary<string, char> entities;
+#if NET_4_0
+		static Lazy <HttpEncoder> defaultEncoder;
+		static Lazy <HttpEncoder> currentEncoderLazy;
+#else
+		static HttpEncoder defaultEncoder;
+#endif
+		static HttpEncoder currentEncoder;
+
+		static IDictionary<string, char> Entities
+		{
+			get
+			{
+				lock (entitiesLock)
+				{
+					if (entities == null)
+						InitEntities();
+
+					return entities;
+				}
+			}
+		}
+
+		public static HttpEncoder Current
+		{
+			get
+			{
+#if NET_4_0
+				if (currentEncoder == null)
+					currentEncoder = currentEncoderLazy.Value;
+#endif
+				return currentEncoder;
+			}
+#if NET_4_0
+			set {
+				if (value == null)
+					throw new ArgumentNullException ("value");
+				currentEncoder = value;
+			}
+#endif
+		}
+
+		public static HttpEncoder Default
+		{
+			get
+			{
+#if NET_4_0
+				return defaultEncoder.Value;
+#else
+				return defaultEncoder;
+#endif
+			}
+		}
+
+		static HttpEncoder()
+		{
+#if NET_4_0
+			defaultEncoder = new Lazy <HttpEncoder> (() => new HttpEncoder ());
+			currentEncoderLazy = new Lazy <HttpEncoder> (new Func <HttpEncoder> (GetCustomEncoderFromConfig));
+#else
+			defaultEncoder = new HttpEncoder();
+			currentEncoder = defaultEncoder;
+#endif
+		}
+
+		public HttpEncoder()
+		{
+		}
+#if NET_4_0	
+		protected internal virtual
+#else
+		internal static
+#endif
+ void HeaderNameValueEncode(string headerName, string headerValue, out string encodedHeaderName, out string encodedHeaderValue)
+		{
+			if (String.IsNullOrEmpty(headerName))
+				encodedHeaderName = headerName;
+			else
+				encodedHeaderName = EncodeHeaderString(headerName);
+
+			if (String.IsNullOrEmpty(headerValue))
+				encodedHeaderValue = headerValue;
+			else
+				encodedHeaderValue = EncodeHeaderString(headerValue);
+		}
+
+		static void StringBuilderAppend(string s, ref StringBuilder sb)
+		{
+			if (sb == null)
+				sb = new StringBuilder(s);
+			else
+				sb.Append(s);
+		}
+
+		static string EncodeHeaderString(string input)
+		{
+			StringBuilder sb = null;
+			char ch;
+
+			for (int i = 0; i < input.Length; i++)
+			{
+				ch = input[i];
+
+				if ((ch < 32 && ch != 9) || ch == 127)
+					StringBuilderAppend(String.Format("%{0:x2}", (int)ch), ref sb);
+			}
+
+			if (sb != null)
+				return sb.ToString();
+
+			return input;
+		}
+#if NET_4_0		
+		protected internal virtual void HtmlAttributeEncode (string value, TextWriter output)
+		{
+
+			if (output == null)
+				throw new ArgumentNullException ("output");
+
+			if (String.IsNullOrEmpty (value))
+				return;
+
+			output.Write (HtmlAttributeEncode (value));
+		}
+
+		protected internal virtual void HtmlDecode (string value, TextWriter output)
+		{
+			if (output == null)
+				throw new ArgumentNullException ("output");
+
+			output.Write (HtmlDecode (value));
+		}
+
+		protected internal virtual void HtmlEncode (string value, TextWriter output)
+		{
+			if (output == null)
+				throw new ArgumentNullException ("output");
+
+			output.Write (HtmlEncode (value));
+		}
+
+		protected internal virtual byte[] UrlEncode (byte[] bytes, int offset, int count)
+		{
+			return UrlEncodeToBytes (bytes, offset, count);
+		}
+
+		static HttpEncoder GetCustomEncoderFromConfig ()
+		{
+			var cfg = WebConfigurationManager.GetSection ("system.web/httpRuntime") as HttpRuntimeSection;
+			string typeName = cfg.EncoderType;
+
+			if (String.Compare (typeName, "System.Web.Util.HttpEncoder", StringComparison.OrdinalIgnoreCase) == 0)
+				return Default;
+			
+			Type t = Type.GetType (typeName, false);
+			if (t == null)
+				throw new ConfigurationErrorsException (String.Format ("Could not load type '{0}'.", typeName));
+			
+			if (!typeof (HttpEncoder).IsAssignableFrom (t))
+				throw new ConfigurationErrorsException (
+					String.Format ("'{0}' is not allowed here because it does not extend class 'System.Web.Util.HttpEncoder'.", typeName)
+				);
+
+			return Activator.CreateInstance (t, false) as HttpEncoder;
+		}
+#endif
+#if NET_4_0
+		protected internal virtual
+#else
+		internal static
+#endif
+ string UrlPathEncode(string value)
+		{
+			if (String.IsNullOrEmpty(value))
+				return value;
+
+			MemoryStream result = new MemoryStream();
+			int length = value.Length;
+			for (int i = 0; i < length; i++)
+				UrlPathEncodeChar(value[i], result);
+
+			return Encoding.ASCII.GetString(result.ToArray());
+		}
+
+		internal static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
+		{
+			if (bytes == null)
+				throw new ArgumentNullException("bytes");
+
+			int blen = bytes.Length;
+			if (blen == 0)
+				return new byte[0];
+
+			if (offset < 0 || offset >= blen)
+				throw new ArgumentOutOfRangeException("offset");
+
+			if (count < 0 || count > blen - offset)
+				throw new ArgumentOutOfRangeException("count");
+
+			MemoryStream result = new MemoryStream(count);
+			int end = offset + count;
+			for (int i = offset; i < end; i++)
+				UrlEncodeChar((char)bytes[i], result, false);
+
+			return result.ToArray();
+		}
+
+		internal static string HtmlEncode(string s)
+		{
+			if (s == null)
+				return null;
+
+			if (s.Length == 0)
+				return String.Empty;
+
+			bool needEncode = false;
+			for (int i = 0; i < s.Length; i++)
+			{
+				char c = s[i];
+				if (c == '&' || c == '"' || c == '<' || c == '>' || c > 159
+#if NET_4_0
+				    || c == '\''
+#endif
+)
+				{
+					needEncode = true;
+					break;
+				}
+			}
+
+			if (!needEncode)
+				return s;
+
+			StringBuilder output = new StringBuilder();
+			char ch;
+			int len = s.Length;
+
+			for (int i = 0; i < len; i++)
+			{
+				switch (s[i])
+				{
+					case '&':
+						output.Append("&amp;");
+						break;
+					case '>':
+						output.Append("&gt;");
+						break;
+					case '<':
+						output.Append("&lt;");
+						break;
+					case '"':
+						output.Append("&quot;");
+						break;
+#if NET_4_0
+					case '\'':
+						output.Append ("&#39;");
+						break;
+#endif
+					case '\uff1c':
+						output.Append("&#65308;");
+						break;
+
+					case '\uff1e':
+						output.Append("&#65310;");
+						break;
+
+					default:
+						ch = s[i];
+						if (ch > 159 && ch < 256)
+						{
+							output.Append("&#");
+							output.Append(((int)ch).ToString(Helpers.InvariantCulture));
+							output.Append(";");
+						}
+						else
+							output.Append(ch);
+						break;
+				}
+			}
+
+			return output.ToString();
+		}
+
+		internal static string HtmlAttributeEncode(string s)
+		{
+#if NET_4_0
+			if (String.IsNullOrEmpty (s))
+				return String.Empty;
+#else
+			if (s == null)
+				return null;
+
+			if (s.Length == 0)
+				return String.Empty;
+#endif
+			bool needEncode = false;
+			for (int i = 0; i < s.Length; i++)
+			{
+				char c = s[i];
+				if (c == '&' || c == '"' || c == '<'
+#if NET_4_0
+				    || c == '\''
+#endif
+)
+				{
+					needEncode = true;
+					break;
+				}
+			}
+
+			if (!needEncode)
+				return s;
+
+			StringBuilder output = new StringBuilder();
+			int len = s.Length;
+			for (int i = 0; i < len; i++)
+				switch (s[i])
+				{
+					case '&':
+						output.Append("&amp;");
+						break;
+					case '"':
+						output.Append("&quot;");
+						break;
+					case '<':
+						output.Append("&lt;");
+						break;
+#if NET_4_0
+				case '\'':
+					output.Append ("&#39;");
+					break;
+#endif
+					default:
+						output.Append(s[i]);
+						break;
+				}
+
+			return output.ToString();
+		}
+
+		internal static string HtmlDecode(string s)
+		{
+			if (s == null)
+				return null;
+
+			if (s.Length == 0)
+				return String.Empty;
+
+			if (s.IndexOf('&') == -1)
+				return s;
+#if NET_4_0
+			StringBuilder rawEntity = new StringBuilder ();
+#endif
+			StringBuilder entity = new StringBuilder();
+			StringBuilder output = new StringBuilder();
+			int len = s.Length;
+			// 0 -> nothing,
+			// 1 -> right after '&'
+			// 2 -> between '&' and ';' but no '#'
+			// 3 -> '#' found after '&' and getting numbers
+			int state = 0;
+			int number = 0;
+			bool is_hex_value = false;
+			bool have_trailing_digits = false;
+
+			for (int i = 0; i < len; i++)
+			{
+				char c = s[i];
+				if (state == 0)
+				{
+					if (c == '&')
+					{
+						entity.Append(c);
+#if NET_4_0
+						rawEntity.Append (c);
+#endif
+						state = 1;
+					}
+					else
+					{
+						output.Append(c);
+					}
+					continue;
+				}
+
+				if (c == '&')
+				{
+					state = 1;
+					if (have_trailing_digits)
+					{
+						entity.Append(number.ToString(Helpers.InvariantCulture));
+						have_trailing_digits = false;
+					}
+
+					output.Append(entity.ToString());
+					entity.Length = 0;
+					entity.Append('&');
+					continue;
+				}
+
+				if (state == 1)
+				{
+					if (c == ';')
+					{
+						state = 0;
+						output.Append(entity.ToString());
+						output.Append(c);
+						entity.Length = 0;
+					}
+					else
+					{
+						number = 0;
+						is_hex_value = false;
+						if (c != '#')
+						{
+							state = 2;
+						}
+						else
+						{
+							state = 3;
+						}
+						entity.Append(c);
+#if NET_4_0
+						rawEntity.Append (c);
+#endif
+					}
+				}
+				else if (state == 2)
+				{
+					entity.Append(c);
+					if (c == ';')
+					{
+						string key = entity.ToString();
+						if (key.Length > 1 && Entities.ContainsKey(key.Substring(1, key.Length - 2)))
+							key = Entities[key.Substring(1, key.Length - 2)].ToString();
+
+						output.Append(key);
+						state = 0;
+						entity.Length = 0;
+#if NET_4_0
+						rawEntity.Length = 0;
+#endif
+					}
+				}
+				else if (state == 3)
+				{
+					if (c == ';')
+					{
+#if NET_4_0
+						if (number == 0)
+							output.Append (rawEntity.ToString () + ";");
+						else
+#endif
+						if (number > 65535)
+						{
+							output.Append("&#");
+							output.Append(number.ToString(Helpers.InvariantCulture));
+							output.Append(";");
+						}
+						else
+						{
+							output.Append((char)number);
+						}
+						state = 0;
+						entity.Length = 0;
+#if NET_4_0
+						rawEntity.Length = 0;
+#endif
+						have_trailing_digits = false;
+					}
+					else if (is_hex_value && Uri.IsHexDigit(c))
+					{
+						number = number * 16 + Uri.FromHex(c);
+						have_trailing_digits = true;
+#if NET_4_0
+						rawEntity.Append (c);
+#endif
+					}
+					else if (Char.IsDigit(c))
+					{
+						number = number * 10 + ((int)c - '0');
+						have_trailing_digits = true;
+#if NET_4_0
+						rawEntity.Append (c);
+#endif
+					}
+					else if (number == 0 && (c == 'x' || c == 'X'))
+					{
+						is_hex_value = true;
+#if NET_4_0
+						rawEntity.Append (c);
+#endif
+					}
+					else
+					{
+						state = 2;
+						if (have_trailing_digits)
+						{
+							entity.Append(number.ToString(Helpers.InvariantCulture));
+							have_trailing_digits = false;
+						}
+						entity.Append(c);
+					}
+				}
+			}
+
+			if (entity.Length > 0)
+			{
+				output.Append(entity.ToString());
+			}
+			else if (have_trailing_digits)
+			{
+				output.Append(number.ToString(Helpers.InvariantCulture));
+			}
+			return output.ToString();
+		}
+
+		internal static bool NotEncoded(char c)
+		{
+			return (c == '!' || c == '(' || c == ')' || c == '*' || c == '-' || c == '.' || c == '_'
+#if !NET_4_0
+ || c == '\''
+#endif
+);
+		}
+
+		internal static void UrlEncodeChar(char c, Stream result, bool isUnicode)
+		{
+			if (c > 255)
+			{
+				//FIXME: what happens when there is an internal error?
+				//if (!isUnicode)
+				//	throw new ArgumentOutOfRangeException ("c", c, "c must be less than 256");
+				int idx;
+				int i = (int)c;
+
+				result.WriteByte((byte)'%');
+				result.WriteByte((byte)'u');
+				idx = i >> 12;
+				result.WriteByte((byte)hexChars[idx]);
+				idx = (i >> 8) & 0x0F;
+				result.WriteByte((byte)hexChars[idx]);
+				idx = (i >> 4) & 0x0F;
+				result.WriteByte((byte)hexChars[idx]);
+				idx = i & 0x0F;
+				result.WriteByte((byte)hexChars[idx]);
+				return;
+			}
+
+			if (c > ' ' && NotEncoded(c))
+			{
+				result.WriteByte((byte)c);
+				return;
+			}
+			if (c == ' ')
+			{
+				result.WriteByte((byte)'+');
+				return;
+			}
+			if ((c < '0') ||
+				(c < 'A' && c > '9') ||
+				(c > 'Z' && c < 'a') ||
+				(c > 'z'))
+			{
+				if (isUnicode && c > 127)
+				{
+					result.WriteByte((byte)'%');
+					result.WriteByte((byte)'u');
+					result.WriteByte((byte)'0');
+					result.WriteByte((byte)'0');
+				}
+				else
+					result.WriteByte((byte)'%');
+
+				int idx = ((int)c) >> 4;
+				result.WriteByte((byte)hexChars[idx]);
+				idx = ((int)c) & 0x0F;
+				result.WriteByte((byte)hexChars[idx]);
+			}
+			else
+				result.WriteByte((byte)c);
+		}
+
+		internal static void UrlPathEncodeChar(char c, Stream result)
+		{
+			if (c < 33 || c > 126)
+			{
+				byte[] bIn = Encoding.UTF8.GetBytes(c.ToString());
+				for (int i = 0; i < bIn.Length; i++)
+				{
+					result.WriteByte((byte)'%');
+					int idx = ((int)bIn[i]) >> 4;
+					result.WriteByte((byte)hexChars[idx]);
+					idx = ((int)bIn[i]) & 0x0F;
+					result.WriteByte((byte)hexChars[idx]);
+				}
+			}
+			else if (c == ' ')
+			{
+				result.WriteByte((byte)'%');
+				result.WriteByte((byte)'2');
+				result.WriteByte((byte)'0');
+			}
+			else
+				result.WriteByte((byte)c);
+		}
+
+		static void InitEntities()
+		{
+			// Build the hash table of HTML entity references.  This list comes
+			// from the HTML 4.01 W3C recommendation.
+			entities = new SortedDictionary<string, char>(StringComparer.Ordinal);
+
+			entities.Add("nbsp", '\u00A0');
+			entities.Add("iexcl", '\u00A1');
+			entities.Add("cent", '\u00A2');
+			entities.Add("pound", '\u00A3');
+			entities.Add("curren", '\u00A4');
+			entities.Add("yen", '\u00A5');
+			entities.Add("brvbar", '\u00A6');
+			entities.Add("sect", '\u00A7');
+			entities.Add("uml", '\u00A8');
+			entities.Add("copy", '\u00A9');
+			entities.Add("ordf", '\u00AA');
+			entities.Add("laquo", '\u00AB');
+			entities.Add("not", '\u00AC');
+			entities.Add("shy", '\u00AD');
+			entities.Add("reg", '\u00AE');
+			entities.Add("macr", '\u00AF');
+			entities.Add("deg", '\u00B0');
+			entities.Add("plusmn", '\u00B1');
+			entities.Add("sup2", '\u00B2');
+			entities.Add("sup3", '\u00B3');
+			entities.Add("acute", '\u00B4');
+			entities.Add("micro", '\u00B5');
+			entities.Add("para", '\u00B6');
+			entities.Add("middot", '\u00B7');
+			entities.Add("cedil", '\u00B8');
+			entities.Add("sup1", '\u00B9');
+			entities.Add("ordm", '\u00BA');
+			entities.Add("raquo", '\u00BB');
+			entities.Add("frac14", '\u00BC');
+			entities.Add("frac12", '\u00BD');
+			entities.Add("frac34", '\u00BE');
+			entities.Add("iquest", '\u00BF');
+			entities.Add("Agrave", '\u00C0');
+			entities.Add("Aacute", '\u00C1');
+			entities.Add("Acirc", '\u00C2');
+			entities.Add("Atilde", '\u00C3');
+			entities.Add("Auml", '\u00C4');
+			entities.Add("Aring", '\u00C5');
+			entities.Add("AElig", '\u00C6');
+			entities.Add("Ccedil", '\u00C7');
+			entities.Add("Egrave", '\u00C8');
+			entities.Add("Eacute", '\u00C9');
+			entities.Add("Ecirc", '\u00CA');
+			entities.Add("Euml", '\u00CB');
+			entities.Add("Igrave", '\u00CC');
+			entities.Add("Iacute", '\u00CD');
+			entities.Add("Icirc", '\u00CE');
+			entities.Add("Iuml", '\u00CF');
+			entities.Add("ETH", '\u00D0');
+			entities.Add("Ntilde", '\u00D1');
+			entities.Add("Ograve", '\u00D2');
+			entities.Add("Oacute", '\u00D3');
+			entities.Add("Ocirc", '\u00D4');
+			entities.Add("Otilde", '\u00D5');
+			entities.Add("Ouml", '\u00D6');
+			entities.Add("times", '\u00D7');
+			entities.Add("Oslash", '\u00D8');
+			entities.Add("Ugrave", '\u00D9');
+			entities.Add("Uacute", '\u00DA');
+			entities.Add("Ucirc", '\u00DB');
+			entities.Add("Uuml", '\u00DC');
+			entities.Add("Yacute", '\u00DD');
+			entities.Add("THORN", '\u00DE');
+			entities.Add("szlig", '\u00DF');
+			entities.Add("agrave", '\u00E0');
+			entities.Add("aacute", '\u00E1');
+			entities.Add("acirc", '\u00E2');
+			entities.Add("atilde", '\u00E3');
+			entities.Add("auml", '\u00E4');
+			entities.Add("aring", '\u00E5');
+			entities.Add("aelig", '\u00E6');
+			entities.Add("ccedil", '\u00E7');
+			entities.Add("egrave", '\u00E8');
+			entities.Add("eacute", '\u00E9');
+			entities.Add("ecirc", '\u00EA');
+			entities.Add("euml", '\u00EB');
+			entities.Add("igrave", '\u00EC');
+			entities.Add("iacute", '\u00ED');
+			entities.Add("icirc", '\u00EE');
+			entities.Add("iuml", '\u00EF');
+			entities.Add("eth", '\u00F0');
+			entities.Add("ntilde", '\u00F1');
+			entities.Add("ograve", '\u00F2');
+			entities.Add("oacute", '\u00F3');
+			entities.Add("ocirc", '\u00F4');
+			entities.Add("otilde", '\u00F5');
+			entities.Add("ouml", '\u00F6');
+			entities.Add("divide", '\u00F7');
+			entities.Add("oslash", '\u00F8');
+			entities.Add("ugrave", '\u00F9');
+			entities.Add("uacute", '\u00FA');
+			entities.Add("ucirc", '\u00FB');
+			entities.Add("uuml", '\u00FC');
+			entities.Add("yacute", '\u00FD');
+			entities.Add("thorn", '\u00FE');
+			entities.Add("yuml", '\u00FF');
+			entities.Add("fnof", '\u0192');
+			entities.Add("Alpha", '\u0391');
+			entities.Add("Beta", '\u0392');
+			entities.Add("Gamma", '\u0393');
+			entities.Add("Delta", '\u0394');
+			entities.Add("Epsilon", '\u0395');
+			entities.Add("Zeta", '\u0396');
+			entities.Add("Eta", '\u0397');
+			entities.Add("Theta", '\u0398');
+			entities.Add("Iota", '\u0399');
+			entities.Add("Kappa", '\u039A');
+			entities.Add("Lambda", '\u039B');
+			entities.Add("Mu", '\u039C');
+			entities.Add("Nu", '\u039D');
+			entities.Add("Xi", '\u039E');
+			entities.Add("Omicron", '\u039F');
+			entities.Add("Pi", '\u03A0');
+			entities.Add("Rho", '\u03A1');
+			entities.Add("Sigma", '\u03A3');
+			entities.Add("Tau", '\u03A4');
+			entities.Add("Upsilon", '\u03A5');
+			entities.Add("Phi", '\u03A6');
+			entities.Add("Chi", '\u03A7');
+			entities.Add("Psi", '\u03A8');
+			entities.Add("Omega", '\u03A9');
+			entities.Add("alpha", '\u03B1');
+			entities.Add("beta", '\u03B2');
+			entities.Add("gamma", '\u03B3');
+			entities.Add("delta", '\u03B4');
+			entities.Add("epsilon", '\u03B5');
+			entities.Add("zeta", '\u03B6');
+			entities.Add("eta", '\u03B7');
+			entities.Add("theta", '\u03B8');
+			entities.Add("iota", '\u03B9');
+			entities.Add("kappa", '\u03BA');
+			entities.Add("lambda", '\u03BB');
+			entities.Add("mu", '\u03BC');
+			entities.Add("nu", '\u03BD');
+			entities.Add("xi", '\u03BE');
+			entities.Add("omicron", '\u03BF');
+			entities.Add("pi", '\u03C0');
+			entities.Add("rho", '\u03C1');
+			entities.Add("sigmaf", '\u03C2');
+			entities.Add("sigma", '\u03C3');
+			entities.Add("tau", '\u03C4');
+			entities.Add("upsilon", '\u03C5');
+			entities.Add("phi", '\u03C6');
+			entities.Add("chi", '\u03C7');
+			entities.Add("psi", '\u03C8');
+			entities.Add("omega", '\u03C9');
+			entities.Add("thetasym", '\u03D1');
+			entities.Add("upsih", '\u03D2');
+			entities.Add("piv", '\u03D6');
+			entities.Add("bull", '\u2022');
+			entities.Add("hellip", '\u2026');
+			entities.Add("prime", '\u2032');
+			entities.Add("Prime", '\u2033');
+			entities.Add("oline", '\u203E');
+			entities.Add("frasl", '\u2044');
+			entities.Add("weierp", '\u2118');
+			entities.Add("image", '\u2111');
+			entities.Add("real", '\u211C');
+			entities.Add("trade", '\u2122');
+			entities.Add("alefsym", '\u2135');
+			entities.Add("larr", '\u2190');
+			entities.Add("uarr", '\u2191');
+			entities.Add("rarr", '\u2192');
+			entities.Add("darr", '\u2193');
+			entities.Add("harr", '\u2194');
+			entities.Add("crarr", '\u21B5');
+			entities.Add("lArr", '\u21D0');
+			entities.Add("uArr", '\u21D1');
+			entities.Add("rArr", '\u21D2');
+			entities.Add("dArr", '\u21D3');
+			entities.Add("hArr", '\u21D4');
+			entities.Add("forall", '\u2200');
+			entities.Add("part", '\u2202');
+			entities.Add("exist", '\u2203');
+			entities.Add("empty", '\u2205');
+			entities.Add("nabla", '\u2207');
+			entities.Add("isin", '\u2208');
+			entities.Add("notin", '\u2209');
+			entities.Add("ni", '\u220B');
+			entities.Add("prod", '\u220F');
+			entities.Add("sum", '\u2211');
+			entities.Add("minus", '\u2212');
+			entities.Add("lowast", '\u2217');
+			entities.Add("radic", '\u221A');
+			entities.Add("prop", '\u221D');
+			entities.Add("infin", '\u221E');
+			entities.Add("ang", '\u2220');
+			entities.Add("and", '\u2227');
+			entities.Add("or", '\u2228');
+			entities.Add("cap", '\u2229');
+			entities.Add("cup", '\u222A');
+			entities.Add("int", '\u222B');
+			entities.Add("there4", '\u2234');
+			entities.Add("sim", '\u223C');
+			entities.Add("cong", '\u2245');
+			entities.Add("asymp", '\u2248');
+			entities.Add("ne", '\u2260');
+			entities.Add("equiv", '\u2261');
+			entities.Add("le", '\u2264');
+			entities.Add("ge", '\u2265');
+			entities.Add("sub", '\u2282');
+			entities.Add("sup", '\u2283');
+			entities.Add("nsub", '\u2284');
+			entities.Add("sube", '\u2286');
+			entities.Add("supe", '\u2287');
+			entities.Add("oplus", '\u2295');
+			entities.Add("otimes", '\u2297');
+			entities.Add("perp", '\u22A5');
+			entities.Add("sdot", '\u22C5');
+			entities.Add("lceil", '\u2308');
+			entities.Add("rceil", '\u2309');
+			entities.Add("lfloor", '\u230A');
+			entities.Add("rfloor", '\u230B');
+			entities.Add("lang", '\u2329');
+			entities.Add("rang", '\u232A');
+			entities.Add("loz", '\u25CA');
+			entities.Add("spades", '\u2660');
+			entities.Add("clubs", '\u2663');
+			entities.Add("hearts", '\u2665');
+			entities.Add("diams", '\u2666');
+			entities.Add("quot", '\u0022');
+			entities.Add("amp", '\u0026');
+			entities.Add("lt", '\u003C');
+			entities.Add("gt", '\u003E');
+			entities.Add("OElig", '\u0152');
+			entities.Add("oelig", '\u0153');
+			entities.Add("Scaron", '\u0160');
+			entities.Add("scaron", '\u0161');
+			entities.Add("Yuml", '\u0178');
+			entities.Add("circ", '\u02C6');
+			entities.Add("tilde", '\u02DC');
+			entities.Add("ensp", '\u2002');
+			entities.Add("emsp", '\u2003');
+			entities.Add("thinsp", '\u2009');
+			entities.Add("zwnj", '\u200C');
+			entities.Add("zwj", '\u200D');
+			entities.Add("lrm", '\u200E');
+			entities.Add("rlm", '\u200F');
+			entities.Add("ndash", '\u2013');
+			entities.Add("mdash", '\u2014');
+			entities.Add("lsquo", '\u2018');
+			entities.Add("rsquo", '\u2019');
+			entities.Add("sbquo", '\u201A');
+			entities.Add("ldquo", '\u201C');
+			entities.Add("rdquo", '\u201D');
+			entities.Add("bdquo", '\u201E');
+			entities.Add("dagger", '\u2020');
+			entities.Add("Dagger", '\u2021');
+			entities.Add("permil", '\u2030');
+			entities.Add("lsaquo", '\u2039');
+			entities.Add("rsaquo", '\u203A');
+			entities.Add("euro", '\u20AC');
+		}
+	}
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HtmlEncoder.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HtmlEncoder.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 033571fb3aa3e46e7b09ad6a0e40f0e0
+timeCreated: 1497586508
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HttpUtility.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HttpUtility.cs
@@ -1,0 +1,766 @@
+﻿// 
+// System.Web.HttpUtility
+//
+// Authors:
+//   Patrik Torstensson (Patrik.Torstensson@labs2.com)
+//   Wictor WilÃ©n (decode/encode functions) (wictor@ibizkit.se)
+//   Tim Coleman (tim@timcoleman.com)
+//   Gonzalo Paniagua Javier (gonzalo@ximian.com)
+//
+// Copyright (C) 2005-2010 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.IO;
+using System.Security.Permissions;
+using System.Text;
+
+namespace RedBlueGames.BulkRename.Dependencies.RestSharp.Contrib
+{
+
+//#if !MONOTOUCH
+//    // CAS - no InheritanceDemand here as the class is sealed
+//    [AspNetHostingPermission(SecurityAction.LinkDemand, Level = AspNetHostingPermissionLevel.Minimal)]
+//#endif
+	public sealed class HttpUtility
+	{
+		sealed class HttpQSCollection : NameValueCollection
+		{
+			public override string ToString()
+			{
+				int count = Count;
+				if (count == 0)
+					return "";
+				StringBuilder sb = new StringBuilder();
+				string[] keys = AllKeys;
+				for (int i = 0; i < count; i++)
+				{
+					sb.AppendFormat("{0}={1}&", keys[i], this[keys[i]]);
+				}
+				if (sb.Length > 0)
+					sb.Length--;
+				return sb.ToString();
+			}
+		}
+
+		#region Constructors
+
+		public HttpUtility()
+		{
+		}
+
+		#endregion // Constructors
+
+		#region Methods
+
+		public static void HtmlAttributeEncode(string s, TextWriter output)
+		{
+			if (output == null)
+			{
+#if NET_4_0
+				throw new ArgumentNullException ("output");
+#else
+				throw new NullReferenceException(".NET emulation");
+#endif
+			}
+#if NET_4_0
+			HttpEncoder.Current.HtmlAttributeEncode (s, output);
+#else
+			output.Write(HttpEncoder.HtmlAttributeEncode(s));
+#endif
+		}
+
+		public static string HtmlAttributeEncode(string s)
+		{
+#if NET_4_0
+			if (s == null)
+				return null;
+			
+			using (var sw = new StringWriter ()) {
+				HttpEncoder.Current.HtmlAttributeEncode (s, sw);
+				return sw.ToString ();
+			}
+#else
+			return HttpEncoder.HtmlAttributeEncode(s);
+#endif
+		}
+
+		public static string UrlDecode(string str)
+		{
+			return UrlDecode(str, Encoding.UTF8);
+		}
+
+		static char[] GetChars(MemoryStream b, Encoding e)
+		{
+			return e.GetChars(b.GetBuffer(), 0, (int)b.Length);
+		}
+
+		static void WriteCharBytes(IList buf, char ch, Encoding e)
+		{
+			if (ch > 255)
+			{
+				foreach (byte b in e.GetBytes(new char[] { ch }))
+					buf.Add(b);
+			}
+			else
+				buf.Add((byte)ch);
+		}
+
+		public static string UrlDecode(string s, Encoding e)
+		{
+			if (null == s)
+				return null;
+
+			if (s.IndexOf('%') == -1 && s.IndexOf('+') == -1)
+				return s;
+
+			if (e == null)
+				e = Encoding.UTF8;
+
+			long len = s.Length;
+			var bytes = new List<byte>();
+			int xchar;
+			char ch;
+
+			for (int i = 0; i < len; i++)
+			{
+				ch = s[i];
+				if (ch == '%' && i + 2 < len && s[i + 1] != '%')
+				{
+					if (s[i + 1] == 'u' && i + 5 < len)
+					{
+						// unicode hex sequence
+						xchar = GetChar(s, i + 2, 4);
+						if (xchar != -1)
+						{
+							WriteCharBytes(bytes, (char)xchar, e);
+							i += 5;
+						}
+						else
+							WriteCharBytes(bytes, '%', e);
+					}
+					else if ((xchar = GetChar(s, i + 1, 2)) != -1)
+					{
+						WriteCharBytes(bytes, (char)xchar, e);
+						i += 2;
+					}
+					else
+					{
+						WriteCharBytes(bytes, '%', e);
+					}
+					continue;
+				}
+
+				if (ch == '+')
+					WriteCharBytes(bytes, ' ', e);
+				else
+					WriteCharBytes(bytes, ch, e);
+			}
+
+			byte[] buf = bytes.ToArray();
+			bytes = null;
+			return e.GetString(buf);
+
+		}
+
+		public static string UrlDecode(byte[] bytes, Encoding e)
+		{
+			if (bytes == null)
+				return null;
+
+			return UrlDecode(bytes, 0, bytes.Length, e);
+		}
+
+		static int GetInt(byte b)
+		{
+			char c = (char)b;
+			if (c >= '0' && c <= '9')
+				return c - '0';
+
+			if (c >= 'a' && c <= 'f')
+				return c - 'a' + 10;
+
+			if (c >= 'A' && c <= 'F')
+				return c - 'A' + 10;
+
+			return -1;
+		}
+
+		static int GetChar(byte[] bytes, int offset, int length)
+		{
+			int value = 0;
+			int end = length + offset;
+			for (int i = offset; i < end; i++)
+			{
+				int current = GetInt(bytes[i]);
+				if (current == -1)
+					return -1;
+				value = (value << 4) + current;
+			}
+
+			return value;
+		}
+
+		static int GetChar(string str, int offset, int length)
+		{
+			int val = 0;
+			int end = length + offset;
+			for (int i = offset; i < end; i++)
+			{
+				char c = str[i];
+				if (c > 127)
+					return -1;
+
+				int current = GetInt((byte)c);
+				if (current == -1)
+					return -1;
+				val = (val << 4) + current;
+			}
+
+			return val;
+		}
+
+		public static string UrlDecode(byte[] bytes, int offset, int count, Encoding e)
+		{
+			if (bytes == null)
+				return null;
+			if (count == 0)
+				return String.Empty;
+
+			if (bytes == null)
+				throw new ArgumentNullException("bytes");
+
+			if (offset < 0 || offset > bytes.Length)
+				throw new ArgumentOutOfRangeException("offset");
+
+			if (count < 0 || offset + count > bytes.Length)
+				throw new ArgumentOutOfRangeException("count");
+
+			StringBuilder output = new StringBuilder();
+			MemoryStream acc = new MemoryStream();
+
+			int end = count + offset;
+			int xchar;
+			for (int i = offset; i < end; i++)
+			{
+				if (bytes[i] == '%' && i + 2 < count && bytes[i + 1] != '%')
+				{
+					if (bytes[i + 1] == (byte)'u' && i + 5 < end)
+					{
+						if (acc.Length > 0)
+						{
+							output.Append(GetChars(acc, e));
+							acc.SetLength(0);
+						}
+						xchar = GetChar(bytes, i + 2, 4);
+						if (xchar != -1)
+						{
+							output.Append((char)xchar);
+							i += 5;
+							continue;
+						}
+					}
+					else if ((xchar = GetChar(bytes, i + 1, 2)) != -1)
+					{
+						acc.WriteByte((byte)xchar);
+						i += 2;
+						continue;
+					}
+				}
+
+				if (acc.Length > 0)
+				{
+					output.Append(GetChars(acc, e));
+					acc.SetLength(0);
+				}
+
+				if (bytes[i] == '+')
+				{
+					output.Append(' ');
+				}
+				else
+				{
+					output.Append((char)bytes[i]);
+				}
+			}
+
+			if (acc.Length > 0)
+			{
+				output.Append(GetChars(acc, e));
+			}
+
+			acc = null;
+			return output.ToString();
+		}
+
+		public static byte[] UrlDecodeToBytes(byte[] bytes)
+		{
+			if (bytes == null)
+				return null;
+
+			return UrlDecodeToBytes(bytes, 0, bytes.Length);
+		}
+
+		public static byte[] UrlDecodeToBytes(string str)
+		{
+			return UrlDecodeToBytes(str, Encoding.UTF8);
+		}
+
+		public static byte[] UrlDecodeToBytes(string str, Encoding e)
+		{
+			if (str == null)
+				return null;
+
+			if (e == null)
+				throw new ArgumentNullException("e");
+
+			return UrlDecodeToBytes(e.GetBytes(str));
+		}
+
+		public static byte[] UrlDecodeToBytes(byte[] bytes, int offset, int count)
+		{
+			if (bytes == null)
+				return null;
+			if (count == 0)
+				return new byte[0];
+
+			int len = bytes.Length;
+			if (offset < 0 || offset >= len)
+				throw new ArgumentOutOfRangeException("offset");
+
+			if (count < 0 || offset > len - count)
+				throw new ArgumentOutOfRangeException("count");
+
+			MemoryStream result = new MemoryStream();
+			int end = offset + count;
+			for (int i = offset; i < end; i++)
+			{
+				char c = (char)bytes[i];
+				if (c == '+')
+				{
+					c = ' ';
+				}
+				else if (c == '%' && i < end - 2)
+				{
+					int xchar = GetChar(bytes, i + 1, 2);
+					if (xchar != -1)
+					{
+						c = (char)xchar;
+						i += 2;
+					}
+				}
+				result.WriteByte((byte)c);
+			}
+
+			return result.ToArray();
+		}
+
+		public static string UrlEncode(string str)
+		{
+			return UrlEncode(str, Encoding.UTF8);
+		}
+
+		public static string UrlEncode(string s, Encoding Enc)
+		{
+			if (s == null)
+				return null;
+
+			if (s == String.Empty)
+				return String.Empty;
+
+			bool needEncode = false;
+			int len = s.Length;
+			for (int i = 0; i < len; i++)
+			{
+				char c = s[i];
+				if ((c < '0') || (c < 'A' && c > '9') || (c > 'Z' && c < 'a') || (c > 'z'))
+				{
+					if (HttpEncoder.NotEncoded(c))
+						continue;
+
+					needEncode = true;
+					break;
+				}
+			}
+
+			if (!needEncode)
+				return s;
+
+			// avoided GetByteCount call
+			byte[] bytes = new byte[Enc.GetMaxByteCount(s.Length)];
+			int realLen = Enc.GetBytes(s, 0, s.Length, bytes, 0);
+			return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, 0, realLen));
+		}
+
+		public static string UrlEncode(byte[] bytes)
+		{
+			if (bytes == null)
+				return null;
+
+			if (bytes.Length == 0)
+				return String.Empty;
+
+			return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, 0, bytes.Length));
+		}
+
+		public static string UrlEncode(byte[] bytes, int offset, int count)
+		{
+			if (bytes == null)
+				return null;
+
+			if (bytes.Length == 0)
+				return String.Empty;
+
+			return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
+		}
+
+		public static byte[] UrlEncodeToBytes(string str)
+		{
+			return UrlEncodeToBytes(str, Encoding.UTF8);
+		}
+
+		public static byte[] UrlEncodeToBytes(string str, Encoding e)
+		{
+			if (str == null)
+				return null;
+
+			if (str.Length == 0)
+				return new byte[0];
+
+			byte[] bytes = e.GetBytes(str);
+			return UrlEncodeToBytes(bytes, 0, bytes.Length);
+		}
+
+		public static byte[] UrlEncodeToBytes(byte[] bytes)
+		{
+			if (bytes == null)
+				return null;
+
+			if (bytes.Length == 0)
+				return new byte[0];
+
+			return UrlEncodeToBytes(bytes, 0, bytes.Length);
+		}
+
+		public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
+		{
+			if (bytes == null)
+				return null;
+#if NET_4_0
+			return HttpEncoder.Current.UrlEncode (bytes, offset, count);
+#else
+			return HttpEncoder.UrlEncodeToBytes(bytes, offset, count);
+#endif
+		}
+
+		public static string UrlEncodeUnicode(string str)
+		{
+			if (str == null)
+				return null;
+
+			return Encoding.ASCII.GetString(UrlEncodeUnicodeToBytes(str));
+		}
+
+		public static byte[] UrlEncodeUnicodeToBytes(string str)
+		{
+			if (str == null)
+				return null;
+
+			if (str.Length == 0)
+				return new byte[0];
+
+			MemoryStream result = new MemoryStream(str.Length);
+			foreach (char c in str)
+			{
+				HttpEncoder.UrlEncodeChar(c, result, true);
+			}
+			return result.ToArray();
+		}
+
+		/// <summary>
+		/// Decodes an HTML-encoded string and returns the decoded string.
+		/// </summary>
+		/// <param name="s">The HTML string to decode. </param>
+		/// <returns>The decoded text.</returns>
+		public static string HtmlDecode(string s)
+		{
+#if NET_4_0
+			if (s == null)
+				return null;
+			
+			using (var sw = new StringWriter ()) {
+				HttpEncoder.Current.HtmlDecode (s, sw);
+				return sw.ToString ();
+			}
+#else
+			return HttpEncoder.HtmlDecode(s);
+#endif
+		}
+
+		/// <summary>
+		/// Decodes an HTML-encoded string and sends the resulting output to a TextWriter output stream.
+		/// </summary>
+		/// <param name="s">The HTML string to decode</param>
+		/// <param name="output">The TextWriter output stream containing the decoded string. </param>
+		public static void HtmlDecode(string s, TextWriter output)
+		{
+			if (output == null)
+			{
+#if NET_4_0
+				throw new ArgumentNullException ("output");
+#else
+				throw new NullReferenceException(".NET emulation");
+#endif
+			}
+
+			if (!String.IsNullOrEmpty(s))
+			{
+#if NET_4_0
+				HttpEncoder.Current.HtmlDecode (s, output);
+#else
+				output.Write(HttpEncoder.HtmlDecode(s));
+#endif
+			}
+		}
+
+		public static string HtmlEncode(string s)
+		{
+#if NET_4_0
+			if (s == null)
+				return null;
+			
+			using (var sw = new StringWriter ()) {
+				HttpEncoder.Current.HtmlEncode (s, sw);
+				return sw.ToString ();
+			}
+#else
+			return HttpEncoder.HtmlEncode(s);
+#endif
+		}
+
+		/// <summary>
+		/// HTML-encodes a string and sends the resulting output to a TextWriter output stream.
+		/// </summary>
+		/// <param name="s">The string to encode. </param>
+		/// <param name="output">The TextWriter output stream containing the encoded string. </param>
+		public static void HtmlEncode(string s, TextWriter output)
+		{
+			if (output == null)
+			{
+#if NET_4_0
+				throw new ArgumentNullException ("output");
+#else
+				throw new NullReferenceException(".NET emulation");
+#endif
+			}
+
+			if (!String.IsNullOrEmpty(s))
+			{
+#if NET_4_0
+				HttpEncoder.Current.HtmlEncode (s, output);
+#else
+				output.Write(HttpEncoder.HtmlEncode(s));
+#endif
+			}
+		}
+#if NET_4_0
+		public static string HtmlEncode (object value)
+		{
+			if (value == null)
+				return null;
+
+			IHtmlString htmlString = value as IHtmlString;
+			if (htmlString != null)
+				return htmlString.ToHtmlString ();
+			
+			return HtmlEncode (value.ToString ());
+		}
+
+		public static string JavaScriptStringEncode (string value)
+		{
+			return JavaScriptStringEncode (value, false);
+		}
+
+		public static string JavaScriptStringEncode (string value, bool addDoubleQuotes)
+		{
+			if (String.IsNullOrEmpty (value))
+				return addDoubleQuotes ? "\"\"" : String.Empty;
+
+			int len = value.Length;
+			bool needEncode = false;
+			char c;
+			for (int i = 0; i < len; i++) {
+				c = value [i];
+
+				if (c >= 0 && c <= 31 || c == 34 || c == 39 || c == 60 || c == 62 || c == 92) {
+					needEncode = true;
+					break;
+				}
+			}
+
+			if (!needEncode)
+				return addDoubleQuotes ? "\"" + value + "\"" : value;
+
+			var sb = new StringBuilder ();
+			if (addDoubleQuotes)
+				sb.Append ('"');
+
+			for (int i = 0; i < len; i++) {
+				c = value [i];
+				if (c >= 0 && c <= 7 || c == 11 || c >= 14 && c <= 31 || c == 39 || c == 60 || c == 62)
+					sb.AppendFormat ("\\u{0:x4}", (int)c);
+				else switch ((int)c) {
+						case 8:
+							sb.Append ("\\b");
+							break;
+
+						case 9:
+							sb.Append ("\\t");
+							break;
+
+						case 10:
+							sb.Append ("\\n");
+							break;
+
+						case 12:
+							sb.Append ("\\f");
+							break;
+
+						case 13:
+							sb.Append ("\\r");
+							break;
+
+						case 34:
+							sb.Append ("\\\"");
+							break;
+
+						case 92:
+							sb.Append ("\\\\");
+							break;
+
+						default:
+							sb.Append (c);
+							break;
+					}
+			}
+
+			if (addDoubleQuotes)
+				sb.Append ('"');
+
+			return sb.ToString ();
+		}
+#endif
+		public static string UrlPathEncode(string s)
+		{
+#if NET_4_0
+			return HttpEncoder.Current.UrlPathEncode (s);
+#else
+			return HttpEncoder.UrlPathEncode(s);
+#endif
+		}
+
+		public static NameValueCollection ParseQueryString(string query)
+		{
+			return ParseQueryString(query, Encoding.UTF8);
+		}
+
+		public static NameValueCollection ParseQueryString(string query, Encoding encoding)
+		{
+			if (query == null)
+				throw new ArgumentNullException("query");
+			if (encoding == null)
+				throw new ArgumentNullException("encoding");
+			if (query.Length == 0 || (query.Length == 1 && query[0] == '?'))
+				return new NameValueCollection();
+			if (query[0] == '?')
+				query = query.Substring(1);
+
+			NameValueCollection result = new HttpQSCollection();
+			ParseQueryString(query, encoding, result);
+			return result;
+		}
+
+		internal static void ParseQueryString(string query, Encoding encoding, NameValueCollection result)
+		{
+			if (query.Length == 0)
+				return;
+
+			string decoded = HtmlDecode(query);
+			int decodedLength = decoded.Length;
+			int namePos = 0;
+			bool first = true;
+			while (namePos <= decodedLength)
+			{
+				int valuePos = -1, valueEnd = -1;
+				for (int q = namePos; q < decodedLength; q++)
+				{
+					if (valuePos == -1 && decoded[q] == '=')
+					{
+						valuePos = q + 1;
+					}
+					else if (decoded[q] == '&')
+					{
+						valueEnd = q;
+						break;
+					}
+				}
+
+				if (first)
+				{
+					first = false;
+					if (decoded[namePos] == '?')
+						namePos++;
+				}
+
+				string name, value;
+				if (valuePos == -1)
+				{
+					name = null;
+					valuePos = namePos;
+				}
+				else
+				{
+					name = UrlDecode(decoded.Substring(namePos, valuePos - namePos - 1), encoding);
+				}
+				if (valueEnd < 0)
+				{
+					namePos = -1;
+					valueEnd = decoded.Length;
+				}
+				else
+				{
+					namePos = valueEnd + 1;
+				}
+				value = UrlDecode(decoded.Substring(valuePos, valueEnd - valuePos), encoding);
+
+				result.Add(name, value);
+				if (namePos == -1)
+					break;
+			}
+		}
+		#endregion // Methods
+	}
+}

--- a/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HttpUtility.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HttpUtility.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ea8dcad80b2a14768b0c8d36ddcae260
+timeCreated: 1497586508
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/AddStringOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/AddStringOperation.cs
@@ -113,25 +113,22 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> include diff.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        public override string Rename(string input, int relativeCount, bool includeDiff)
+        public override string Rename(string input, int relativeCount)
         {
             var modifiedName = input;
             if (!string.IsNullOrEmpty(this.Prefix))
             {
-                var prefix = includeDiff ? BaseRenameOperation.ColorStringForAdd(this.Prefix) : this.Prefix;
-                modifiedName = string.Concat(prefix, modifiedName);
+                modifiedName = string.Concat(this.Prefix, modifiedName);
             }
 
             if (!string.IsNullOrEmpty(this.Suffix))
             {
-                var suffix = includeDiff ? BaseRenameOperation.ColorStringForAdd(this.Suffix) : this.Suffix;
-                modifiedName = string.Concat(modifiedName, suffix);
+                modifiedName = string.Concat(modifiedName, this.Suffix);
             }
 
             return modifiedName;

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/BaseRenameOperation.cs
@@ -35,10 +35,6 @@ namespace RedBlueGames.BulkRename
     /// </summary>
     public abstract class BaseRenameOperation : IRenameOperation
     {
-        private const string AddedTextColorTag = "<color=green>";
-        private const string DeletedTextColorTag = "<color=red>";
-        private const string EndColorTag = "</color>";
-
         /// <summary>
         /// Events that are returned by the GUI draw call to indicate what input was pressed.
         /// </summary>
@@ -96,13 +92,12 @@ namespace RedBlueGames.BulkRename
         protected abstract string HeadingLabel { get; }
 
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> include diff.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        public abstract string Rename(string input, int relativeCount, bool includeDiff);
+        public abstract string Rename(string input, int relativeCount);
 
         /// <summary>
         /// Clone this instance.
@@ -128,26 +123,6 @@ namespace RedBlueGames.BulkRename
             EditorGUI.indentLevel--;
 
             return buttonEvent;
-        }
-
-        /// <summary>
-        /// Colors a string to represent an Added string (for a diff)
-        /// </summary>
-        /// <returns>The string colored as if it was added.</returns>
-        /// <param name="stringToColor">String to color.</param>
-        protected static string ColorStringForAdd(string stringToColor)
-        {
-            return string.Concat(AddedTextColorTag, stringToColor, EndColorTag);
-        }
-
-        /// <summary>
-        /// Colors a string to represent a Deleted string (for a diff)
-        /// </summary>
-        /// <returns>The string colored as if it was deleted.</returns>
-        /// <param name="stringToColor">String to color.</param>
-        protected static string ColorStringForDelete(string stringToColor)
-        {
-            return string.Concat(DeletedTextColorTag, stringToColor, EndColorTag);
         }
 
         /// <summary>

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/EnumerateOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/EnumerateOperation.cs
@@ -113,13 +113,12 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> include diff.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        public override string Rename(string input, int relativeCount, bool includeDiff)
+        public override string Rename(string input, int relativeCount)
         {
             var modifiedName = input;
             var currentCount = this.StartingCount + relativeCount;
@@ -129,12 +128,6 @@ namespace RedBlueGames.BulkRename
                 try
                 {
                     var currentCountAsString = currentCount.ToString(this.CountFormat);
-
-                    if (includeDiff)
-                    {
-                        currentCountAsString = string.Concat(BaseRenameOperation.ColorStringForAdd(currentCountAsString));
-                    }
-
                     modifiedName = string.Concat(modifiedName, currentCountAsString);
                 }
                 catch (System.FormatException)

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/IRenameOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/IRenameOperation.cs
@@ -29,12 +29,11 @@ namespace RedBlueGames.BulkRename
     public interface IRenameOperation
     {
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> output the string with diffed text.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        string Rename(string input, int relativeCount, bool includeDiff);
+        string Rename(string input, int relativeCount);
     }
 }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
@@ -169,9 +169,8 @@ namespace RedBlueGames.BulkRename
 
                     if (!string.IsNullOrEmpty(this.SearchString))
                     {
-                        // Create capture group regex to extract the matched string
                         // Escape the non-regex search string to prevent any embedded patterns from being interpretted as regex.
-                        searchStringRegexPattern = string.Concat("(", Regex.Escape(this.SearchString), ")");
+                        searchStringRegexPattern = string.Concat(Regex.Escape(this.SearchString));
                     }
 
                     return searchStringRegexPattern;
@@ -205,40 +204,21 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> include diff.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        public override string Rename(string input, int relativeCount, bool includeDiff)
+        public override string Rename(string input, int relativeCount)
         {
             if (!string.IsNullOrEmpty(this.ActiveSearchPattern))
             {
                 var regexOptions = this.SearchIsCaseSensitive ? default(RegexOptions) : RegexOptions.IgnoreCase;
+                var replacement = this.ActiveReplacementPattern;
 
-                var replacement = string.Empty;
-                if (includeDiff)
-                {
-                    replacement = BaseRenameOperation.ColorStringForDelete("$&");
-
-                    // If replacement pattern is empty is screws up the green color tags on the diff.
-                    if (!string.IsNullOrEmpty(this.ActiveReplacementPattern))
-                    {
-                        replacement += BaseRenameOperation.ColorStringForAdd(this.ActiveReplacementPattern);
-                    }
-                }
-                else
-                {
-                    replacement = this.ActiveReplacementPattern;
-                }
-
-                // Regex gives us two features - case insensitivity and capture groups. Capture groups
-                // are used so that the diff shows the term that is replaced, not the term that replaces it.
-                // (ex. Char_Herohero searching for hero replacing with 'z' should show "Char_Herozheroz" not 
-                // "Char_herozheroz".
                 try
                 {
+                    // Regex gives us case sensitivity, even when not searching with regex.
                     return Regex.Replace(input, this.ActiveSearchPattern, replacement, regexOptions);
                 }
                 catch (System.ArgumentException)

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/TrimCharactersOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/TrimCharactersOperation.cs
@@ -113,49 +113,28 @@ namespace RedBlueGames.BulkRename
         }
 
         /// <summary>
-        /// Rename the specified input, using the relativeCount. Optionally output the string as a diff.
+        /// Rename the specified input, using the relativeCount.
         /// </summary>
         /// <param name="input">Input String to rename.</param>
         /// <param name="relativeCount">Relative count. This can be used for enumeration.</param>
-        /// <param name="includeDiff">If set to <c>true</c> include diff.</param>
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
-        public override string Rename(string input, int relativeCount, bool includeDiff)
+        public override string Rename(string input, int relativeCount)
         {
             var modifiedName = input;
 
             // Trim Front chars
-            string trimmedFrontChars = string.Empty;
             if (this.NumFrontDeleteChars > 0)
             {
                 var numCharsToDelete = Mathf.Min(this.NumFrontDeleteChars, input.Length);
-                trimmedFrontChars = input.Substring(0, numCharsToDelete);
-
                 modifiedName = modifiedName.Remove(0, numCharsToDelete);
             }
 
             // Trim Back chars
-            string trimmedBackChars = string.Empty;
             if (this.NumBackDeleteChars > 0)
             {
                 var numCharsToDelete = Mathf.Min(this.NumBackDeleteChars, modifiedName.Length);
                 int startIndex = modifiedName.Length - numCharsToDelete;
-                trimmedBackChars = modifiedName.Substring(startIndex, numCharsToDelete);
-
                 modifiedName = modifiedName.Remove(startIndex, numCharsToDelete);
-            }
-
-            // When showing rich text, add back in the trimmed characters
-            if (includeDiff)
-            {
-                if (!string.IsNullOrEmpty(trimmedFrontChars))
-                {
-                    modifiedName = string.Concat(BaseRenameOperation.ColorStringForDelete(trimmedFrontChars), modifiedName);
-                }
-
-                if (!string.IsNullOrEmpty(trimmedBackChars))
-                {
-                    modifiedName = string.Concat(modifiedName, BaseRenameOperation.ColorStringForDelete(trimmedBackChars));
-                }
             }
 
             return modifiedName;

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
@@ -18,7 +18,7 @@
             var expected = name;
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -36,7 +36,7 @@
             var expected = "CHAR_A_Spawn";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -53,7 +53,7 @@
             var expected = "StlDdad";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -70,7 +70,7 @@
             var expected = name;
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -88,7 +88,7 @@
             var expected = "Char_Link_Spawn";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -107,7 +107,7 @@
             var expected = "blahblah";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -126,7 +126,7 @@
             var expected = "ZELDA";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -145,7 +145,7 @@
             var expected = "blah";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -163,7 +163,7 @@
             var expected = name;
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -182,7 +182,7 @@
             var expected = "CHAR_A_Spawn";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -200,7 +200,7 @@
             var expected = "StlDdad";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -218,7 +218,7 @@
             var expected = name;
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -237,7 +237,7 @@
             var expected = "Char_Link_Spawn";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -257,7 +257,7 @@
             var expected = "blahblah";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -277,7 +277,7 @@
             var expected = "ZELDA";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -297,7 +297,7 @@
             var expected = "blah";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -316,7 +316,7 @@
             var expected = "YepYepWoot";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -335,7 +335,7 @@
             var expected = "Char_Hero_Woot";
 
             // Act
-            string result = replaceStringOp.Rename(name, 0, false);
+            string result = replaceStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -352,7 +352,7 @@
             var expected = name;
 
             // Act
-            string result = addStringOp.Rename(name, 0, false);
+            string result = addStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -369,7 +369,7 @@
             var expected = "Char_Hero_Spawn";
 
             // Act
-            string result = addStringOp.Rename(name, 0, false);
+            string result = addStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -386,7 +386,7 @@
             var expected = name;
 
             // Act
-            string result = addStringOp.Rename(name, 0, false);
+            string result = addStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -403,7 +403,7 @@
             var expected = "Char_Hero_Spawn";
 
             // Act
-            string result = addStringOp.Rename(name, 0, false);
+            string result = addStringOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -421,7 +421,7 @@
             var expected = name;
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -439,7 +439,7 @@
             var expected = "har_Hero";
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -457,7 +457,7 @@
             var expected = "Char_Her";
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -475,7 +475,7 @@
             var expected = "har_Her";
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -493,7 +493,7 @@
             var expected = string.Empty;
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -511,7 +511,7 @@
             var expected = string.Empty;
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -529,7 +529,7 @@
             var expected = name;
 
             // Act
-            string result = trimCharactersOp.Rename(name, 0, false);
+            string result = trimCharactersOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -546,7 +546,7 @@
             var expected = name;
 
             // Act
-            string result = enumerateOp.Rename(name, 0, false);
+            string result = enumerateOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -564,7 +564,7 @@
             var expected = "Char_Hero0";
 
             // Act
-            string result = enumerateOp.Rename(name, 0, false);
+            string result = enumerateOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -599,7 +599,7 @@
             var results = new List<string>(names.Length);
             for (int i = 0; i < names.Length; ++i)
             {
-                results.Add(enumerateOp.Rename(names[i], i, false));
+                results.Add(enumerateOp.Rename(names[i], i));
             }
 
             // Assert
@@ -625,7 +625,7 @@
             var expected = "Char_Hero-1";
 
             // Act
-            string result = enumerateOp.Rename(name, 0, false);
+            string result = enumerateOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -642,7 +642,7 @@
             var expected = "Char_Hero";
 
             // Act
-            string result = enumerateOp.Rename(name, 0, false);
+            string result = enumerateOp.Rename(name, 0);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -681,7 +681,7 @@
             var expected = "a_hat_ZeroAA0100";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = bulkRenamer.GetRenamePreviews(name)[0].NewName;
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -717,8 +717,8 @@
             var expectedReversed = "_Hero_Idle";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
-            string resultReversed = renamerReversed.GetRenamedStrings(false, name)[0];
+            string result = bulkRenamer.GetRenamePreviews(name)[0].NewName;
+            string resultReversed = renamerReversed.GetRenamePreviews(name)[0].NewName;
 
             // Assert
             Assert.AreEqual(expected, result);

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerUnitTests.cs
@@ -12,15 +12,13 @@
         {
             // Arrange
             var name = "ThisIsAName";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = string.Empty;
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -31,16 +29,14 @@
         {
             // Arrange
             var name = "CHAR_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Hero";
             replaceStringOp.ReplacementString = "A";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "CHAR_A_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -51,15 +47,13 @@
         {
             // Arrange
             var name = "StoolDoodad";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "o";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "StlDdad";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -70,15 +64,13 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Heroine";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -89,16 +81,14 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchString = "Hero";
             replaceStringOp.ReplacementString = "Link";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "Char_Link_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -108,18 +98,16 @@
         public void SearchString_DoesNotMatchCase_Replaces()
         {
             // Arrange
-            var objectName = "ZELDAzelda";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZELDAzelda";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchIsCaseSensitive = false;
             replaceStringOp.SearchString = "ZelDa";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blahblah";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -129,18 +117,16 @@
         public void SearchStringCaseSensitive_DoesNotMatchCase_DoesNotReplace()
         {
             // Arrange
-            var objectName = "ZELDA";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZELDA";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.SearchString = "zelda";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "ZELDA";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -150,18 +136,16 @@
         public void SearchStringCaseSensitive_MatchesCase_Replaces()
         {
             // Arrange
-            var objectName = "ZeldA";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZeldA";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.SearchString = "ZeldA";
             replaceStringOp.ReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blah";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -172,16 +156,14 @@
         {
             // Arrange
             var name = "ThisIsAName";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = string.Empty;
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -192,17 +174,15 @@
         {
             // Arrange
             var name = "CHAR_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "Hero";
             replaceStringOp.RegexReplacementString = "A";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "CHAR_A_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -213,16 +193,14 @@
         {
             // Arrange
             var name = "StoolDoodad";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "o";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "StlDdad";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -233,16 +211,14 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "Heroine";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -253,17 +229,15 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "Hero";
             replaceStringOp.RegexReplacementString = "Link";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "Char_Link_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -273,19 +247,17 @@
         public void SearchRegex_DoesNotMatchCase_Replaces()
         {
             // Arrange
-            var objectName = "ZELDAzelda";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZELDAzelda";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.SearchIsCaseSensitive = false;
             replaceStringOp.RegexSearchString = "ZelDa";
             replaceStringOp.RegexReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blahblah";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -295,19 +267,17 @@
         public void SearchRegexCaseSensitive_DoesNotMatchCase_DoesNotReplace()
         {
             // Arrange
-            var objectName = "ZELDA";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZELDA";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.RegexSearchString = "zelda";
             replaceStringOp.RegexReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "ZELDA";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -317,19 +287,17 @@
         public void SearchRegexCaseSensitive_MatchesCase_Replaces()
         {
             // Arrange
-            var objectName = "ZeldA";
-            var bulkRenamer = new BulkRenamer();
+            var name = "ZeldA";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.SearchIsCaseSensitive = true;
             replaceStringOp.RegexSearchString = "ZeldA";
             replaceStringOp.RegexReplacementString = "blah";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "blah";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -339,18 +307,16 @@
         public void SearchRegex_SpecialCharactersInSearch_Replaces()
         {
             // Arrange
-            var objectName = "Char_Hero_Woot";
-            var bulkRenamer = new BulkRenamer();
+            var name = "Char_Hero_Woot";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "[a-zA-Z]*_";
             replaceStringOp.RegexReplacementString = "Yep";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "YepYepWoot";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -360,18 +326,16 @@
         public void SearchRegex_EscapeCharactersInSearch_Replaces()
         {
             // Arrange
-            var objectName = "Char.Hero.Woot";
-            var bulkRenamer = new BulkRenamer();
+            var name = "Char.Hero.Woot";
             var replaceStringOp = new ReplaceStringOperation();
             replaceStringOp.UseRegex = true;
             replaceStringOp.RegexSearchString = "\\.";
             replaceStringOp.RegexReplacementString = "_";
-            bulkRenamer.SetRenameOperation(replaceStringOp);
 
             var expected = "Char_Hero_Woot";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, objectName)[0];
+            string result = replaceStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -382,15 +346,13 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Prefix = string.Empty;
-            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = addStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -401,15 +363,13 @@
         {
             // Arrange
             var name = "Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Prefix = "Char_";
-            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = "Char_Hero_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = addStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -420,15 +380,13 @@
         {
             // Arrange
             var name = "Char_Hero_Spawn";
-            var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Suffix = string.Empty;
-            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = addStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -439,15 +397,13 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var addStringOp = new AddStringOperation();
             addStringOp.Suffix = "_Spawn";
-            bulkRenamer.SetRenameOperation(addStringOp);
 
             var expected = "Char_Hero_Spawn";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = addStringOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -458,16 +414,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 0;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -478,16 +432,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 1;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "har_Hero";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -498,16 +450,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 0;
             trimCharactersOp.NumBackDeleteChars = 1;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "Char_Her";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -518,16 +468,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = 1;
             trimCharactersOp.NumBackDeleteChars = 1;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = "har_Her";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -538,16 +486,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = name.Length + 2;
             trimCharactersOp.NumBackDeleteChars = 0;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = string.Empty;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -558,16 +504,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = name.Length;
             trimCharactersOp.NumBackDeleteChars = name.Length;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = string.Empty;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -578,16 +522,14 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var trimCharactersOp = new TrimCharactersOperation();
             trimCharactersOp.NumFrontDeleteChars = -1;
             trimCharactersOp.NumBackDeleteChars = -10;
-            bulkRenamer.SetRenameOperation(trimCharactersOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = trimCharactersOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -598,15 +540,13 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = string.Empty;
-            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expected = name;
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = enumerateOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -616,17 +556,15 @@
         public void Enumerating_SingleDigitFormat_AddsCount()
         {
             // Arrange
-            var bulkRenamer = new BulkRenamer();
             var name = "Char_Hero";
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = 0;
-            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expected = "Char_Hero0";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = enumerateOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -644,11 +582,9 @@
                 "BlockD",
                 "BlockE",
             };
-            var bulkRenamer = new BulkRenamer();
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = 1;
-            bulkRenamer.SetRenameOperation(enumerateOp);
 
             var expectedNames = new string[]
             {
@@ -660,14 +596,18 @@
             };
 
             // Act
-            var results = bulkRenamer.GetRenamedStrings(false, names);
+            var results = new List<string>(names.Length);
+            for (int i = 0; i < names.Length; ++i)
+            {
+                results.Add(enumerateOp.Rename(names[i], i, false));
+            }
 
             // Assert
             Assert.AreEqual(
                 expectedNames.Length,
-                results.Length,
+                results.Count,
                 "Expected Results and results should have the same number of entries but didn't.");
-            for (int i = 0; i < results.Length; ++i)
+            for (int i = 0; i < results.Count; ++i)
             {
                 var expected = expectedNames[i];
                 Assert.AreEqual(expected, results[i]);
@@ -679,15 +619,13 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "0";
             enumerateOp.StartingCount = -1;
-            bulkRenamer.SetRenameOperation(enumerateOp);
             var expected = "Char_Hero-1";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = enumerateOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
@@ -698,22 +636,20 @@
         {
             // Arrange
             var name = "Char_Hero";
-            var bulkRenamer = new BulkRenamer();
             var enumerateOp = new EnumerateOperation();
             enumerateOp.CountFormat = "s";
             enumerateOp.StartingCount = 100;
-            bulkRenamer.SetRenameOperation(enumerateOp);
             var expected = "Char_Hero";
 
             // Act
-            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string result = enumerateOp.Rename(name, 0, false);
 
             // Assert
             Assert.AreEqual(expected, result);
         }
 
         [Test]
-        public void AllOperations_ValidOperations_RenamesCorrectly()
+        public void BulkRenamer_AllOperations_RenamesCorrectly()
         {
             // Arrange
             var bulkRenamer = new BulkRenamer();
@@ -749,6 +685,44 @@
 
             // Assert
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void BulkRenamer_OrderSensitiveOps_RespectsOrder()
+        {
+            // Arrange
+            var name = "Char_Hero_Idle";
+
+            var replaceStringOp = new ReplaceStringOperation();
+            replaceStringOp.SearchString = "ar_He";
+            replaceStringOp.ReplacementString = "baboon";
+
+            var trimCharactersOp = new TrimCharactersOperation();
+            trimCharactersOp.NumFrontDeleteChars = 4;
+
+            var listOfOperations = new List<IRenameOperation>();
+            listOfOperations.Add(replaceStringOp);
+            listOfOperations.Add(trimCharactersOp);
+
+            var bulkRenamer = new BulkRenamer();
+            bulkRenamer.SetRenameOperations(listOfOperations);
+
+            var renamerReversed = new BulkRenamer();
+            var operationsReversed = new List<IRenameOperation>();
+            operationsReversed.Add(trimCharactersOp);
+            operationsReversed.Add(replaceStringOp);
+            renamerReversed.SetRenameOperations(operationsReversed);
+
+            var expected = "boonro_Idle";
+            var expectedReversed = "_Hero_Idle";
+
+            // Act
+            string result = bulkRenamer.GetRenamedStrings(false, name)[0];
+            string resultReversed = renamerReversed.GetRenamedStrings(false, name)[0];
+
+            // Assert
+            Assert.AreEqual(expected, result);
+            Assert.AreEqual(expectedReversed, resultReversed);
         }
     }
 }

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -96,17 +96,11 @@
     <Parser ParserId="StyleCop.CSharp.CsParser">
       <ParserSettings>
         <CollectionProperty Name="GeneratedFileFilters">
-          <Value>[^a-z ]RBPackageExporter.cs</Value>
-          <Value>[^a-z ]IStyleCopIgnoreUtilityView.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtility.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityData.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityDirectoryView.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityFileTreeView.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityFileView.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityPath.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityPrefs.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityWindow.cs</Value>
-          <Value>[^a-z ]StyleCopIgnoreUtilityXMLTool.cs</Value>
+          <Value>[^a-z ]Helpers.cs</Value>
+          <Value>[^a-z ]HtmlEncoder.cs</Value>
+          <Value>[^a-z ]HttpUtility.cs</Value>
+          <Value>[^a-z ]DiffMatchPatch.cs</Value>
+          <Value>[^a-z ]DiffMatchPatchTest.cs</Value>
           <Value>[^a-z ]BulkRenamerUnitTests.cs</Value>
         </CollectionProperty>
       </ParserSettings>


### PR DESCRIPTION
Instead of supplying an option to RenameOps to spit back out a string that looks like a diff, I'm using a diff library. This will fix bugs caused by passing a diff string into the next operation in a BulkRename. I could still use the library to do an op-wise diff, but we'd need to rework the GUI to show it.

Fixes Issue #50.