### PR TITLE
Add simple version of RemoveCharactersOp

### DIFF
--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/RemoveCharactersOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/RemoveCharactersOperation.cs
@@ -30,25 +30,27 @@ namespace RedBlueGames.BulkRename
     using UnityEngine;
 
     /// <summary>
-    /// RenameOperation that changes the case of the characters in the name.
+    /// RenameOperation that removes specific characters from the names.
     /// </summary>
-    public class ChangeCaseOperation : BaseRenameOperation
+    public class RemoveCharactersOperation : BaseRenameOperation
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RedBlueGames.BulkRename.ChangeCaseOperation"/> class.
+        /// Initializes a new instance of the <see cref="RedBlueGames.BulkRename.RemoveCharactersOperation"/> class.
         /// </summary>
-        public ChangeCaseOperation()
+        public RemoveCharactersOperation()
         {
-            this.ToUpper = false;
+            this.Characters = string.Empty;
+            this.IsCaseSensitive = false;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RedBlueGames.BulkRename.ChangeCaseOperation"/> class by copying another.
+        /// Initializes a new instance of the <see cref="RedBlueGames.BulkRename.RemoveCharactersOperation"/> class.
         /// </summary>
         /// <param name="operationToCopy">Operation to copy.</param>
-        public ChangeCaseOperation(ChangeCaseOperation operationToCopy)
+        public RemoveCharactersOperation(RemoveCharactersOperation operationToCopy)
         {
-            this.ToUpper = operationToCopy.ToUpper;
+            this.Characters = operationToCopy.Characters;
+            this.IsCaseSensitive = operationToCopy.IsCaseSensitive;
         }
 
         /// <summary>
@@ -59,7 +61,7 @@ namespace RedBlueGames.BulkRename
         {
             get
             {
-                return "Change Case";
+                return "Remove Characters";
             }
         }
 
@@ -71,15 +73,21 @@ namespace RedBlueGames.BulkRename
         {
             get
             {
-                return 4;
+                return 6;
             }
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="RedBlueGames.BulkRename.ChangeCaseOperation"/> changes the case to uppercase.
+        /// Gets or sets the characters to remove.
         /// </summary>
-        /// <value><c>true</c> if to upper; otherwise, <c>false</c>.</value>
-        public bool ToUpper { get; set; }
+        /// <value>The characters.</value>
+        public string Characters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance searches for the characters using case sensitivity.
+        /// </summary>
+        /// <value><c>true</c> if the search is case sensitive; otherwise, <c>false</c>.</value>
+        public bool IsCaseSensitive { get; set; }
 
         /// <summary>
         /// Gets the heading label for the Rename Operation.
@@ -89,7 +97,7 @@ namespace RedBlueGames.BulkRename
         {
             get
             {
-                return "Change Case";
+                return "Remove Characters";
             }
         }
 
@@ -99,7 +107,7 @@ namespace RedBlueGames.BulkRename
         /// <returns>A clone of this instance</returns>
         public override BaseRenameOperation Clone()
         {
-            var clone = new ChangeCaseOperation(this);
+            var clone = new RemoveCharactersOperation(this);
             return clone;
         }
 
@@ -111,13 +119,25 @@ namespace RedBlueGames.BulkRename
         /// <returns>A new string renamed according to the rename operation's rules.</returns>
         public override string Rename(string input, int relativeCount)
         {
-            if (this.ToUpper)
+            if (!string.IsNullOrEmpty(this.Characters))
             {
-                return input.ToUpper();
+                var regexOptions = this.IsCaseSensitive ? default(RegexOptions) : RegexOptions.IgnoreCase;
+                var replacement = string.Empty;
+
+                try
+                {
+                    var regexPattern = Regex.Escape(this.Characters);
+                    var charactersAsRegex = string.Concat("[", regexPattern, "]");
+                    return Regex.Replace(input, charactersAsRegex, replacement, regexOptions);
+                }
+                catch (System.ArgumentException)
+                {
+                    return input;
+                }
             }
             else
             {
-                return input.ToLower();
+                return input;
             }
         }
 
@@ -126,7 +146,11 @@ namespace RedBlueGames.BulkRename
         /// </summary>
         protected override void DrawContents()
         {   
-            this.ToUpper = EditorGUILayout.Toggle("To Uppercase", this.ToUpper);
+            var charactersFieldContent = new GUIContent("Characters to Remove", "All characters that will be removed from the names.");
+            this.Characters = EditorGUILayout.TextField(charactersFieldContent, this.Characters);
+
+            var caseSensitiveToggleContent = new GUIContent("Case Sensitive", "Flag the search to match only the specified case");
+            this.IsCaseSensitive = EditorGUILayout.Toggle(caseSensitiveToggleContent, this.IsCaseSensitive);
         }
     }
 }

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/RemoveCharactersOperation.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/RemoveCharactersOperation.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a41e0c3854ae3459da39c4c635e03ad3
+timeCreated: 1495391168
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
+++ b/Assets/RedBlueGames/BulkRename/Editor/Operations/ReplaceStringOperation.cs
@@ -89,7 +89,8 @@ namespace RedBlueGames.BulkRename
         /// <value><c>true</c> if input is a regular expression; otherwise, <c>false</c>.</value>
         public bool UseRegex { get; set; }
 
-        /// Gets or sets the search string, used to determine what text to replace.
+        /// <summary>
+        /// Gets or sets the search string that will be replaced.
         /// </summary>
         /// <value>The search string.</value>
         public string SearchString { get; set; }

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/RemoveCharactersOpTests.cs
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/RemoveCharactersOpTests.cs
@@ -1,0 +1,43 @@
+﻿namespace RedBlueGames.BulkRename.Tests
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class RemoveCharactersOpTests
+    {
+        [Test]
+        public void RemoveCharacters_EmptyTarget_IsUnchanged()
+        {
+            // Arrange
+            var name = string.Empty;
+            var removeCharactersOp = new RemoveCharactersOperation();
+
+            var expected = string.Empty;
+
+            // Act
+            string result = removeCharactersOp.Rename(name, 0);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void RemoveCharacters_RemoveSymbols_RemovesOnlySymbols()
+        {
+            // Arrange
+            var name = "A!@#$%BD*(";
+            var removeCharactersOp = new RemoveCharactersOperation();
+            removeCharactersOp.Characters = "!@#$%^&*()";
+
+            var expected = "ABD";
+
+            // Act
+            string result = removeCharactersOp.Rename(name, 0);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Assets/RedBlueGames/BulkRename/Tests/Editor/RemoveCharactersOpTests.cs.meta
+++ b/Assets/RedBlueGames/BulkRename/Tests/Editor/RemoveCharactersOpTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 39376b2f3472e4276b8b5d5785645b44
+timeCreated: 1480087188
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0a7c15273828e41889e77d22e91f098b
+folderAsset: yes
+timeCreated: 1497937982
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/RedBlueGames.meta
+++ b/Assets/Resources/RedBlueGames.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 19ad2f10f49b64e1191e4c2e7bd21902
+folderAsset: yes
+timeCreated: 1497937983
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/RedBlueGames/StyleCopIgnoreUtilitySettings.asset
+++ b/Assets/Resources/RedBlueGames/StyleCopIgnoreUtilitySettings.asset
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 233936b3dbd5f664680fbfd466644735, type: 3}
+  m_Name: StyleCopIgnoreUtilitySettings
+  m_EditorClassIdentifier: 
+  styleCopSettingsFilePath:
+    relativePath: /Settings.StyleCop
+  ignoredFilePaths:
+  - relativePath: /Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/Helpers.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HtmlEncoder.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Editor/Google-Diff/HttpUtility/HttpUtility.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Editor/Google-Diff/DiffMatchPatch.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/AddStringOpTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/BulkRenamerTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/ChangeCaseOpTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/DiffMatchPatchTest.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/EnumerateOpTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/RemoveCharactersOpTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/ReplaceStringOpTests.cs
+  - relativePath: /Assets/RedBlueGames/BulkRename/Tests/Editor/TrimOpTests.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/IStyleCopIgnoreUtilityView.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtility.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityData.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityDirectoryView.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityFileTreeView.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityFileView.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityPath.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityPrefs.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityWindow.cs
+  - relativePath: /Assets/RedBlueGames/StyleCopIgnoreUtility/Editor/StyleCopIgnoreUtilityXMLTool.cs

--- a/Assets/Resources/RedBlueGames/StyleCopIgnoreUtilitySettings.asset.meta
+++ b/Assets/Resources/RedBlueGames/StyleCopIgnoreUtilitySettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a26f10fe34c94c0c9397daa14fa282a
+timeCreated: 1497937983
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -100,8 +100,24 @@
           <Value>[^a-z ]HtmlEncoder.cs</Value>
           <Value>[^a-z ]HttpUtility.cs</Value>
           <Value>[^a-z ]DiffMatchPatch.cs</Value>
+          <Value>[^a-z ]AddStringOpTests.cs</Value>
+          <Value>[^a-z ]BulkRenamerTests.cs</Value>
+          <Value>[^a-z ]ChangeCaseOpTests.cs</Value>
           <Value>[^a-z ]DiffMatchPatchTest.cs</Value>
-          <Value>[^a-z ]BulkRenamerUnitTests.cs</Value>
+          <Value>[^a-z ]EnumerateOpTests.cs</Value>
+          <Value>[^a-z ]RemoveCharactersOpTests.cs</Value>
+          <Value>[^a-z ]ReplaceStringOpTests.cs</Value>
+          <Value>[^a-z ]TrimOpTests.cs</Value>
+          <Value>[^a-z ]IStyleCopIgnoreUtilityView.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtility.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityData.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityDirectoryView.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityFileTreeView.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityFileView.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityPath.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityPrefs.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityWindow.cs</Value>
+          <Value>[^a-z ]StyleCopIgnoreUtilityXMLTool.cs</Value>
         </CollectionProperty>
       </ParserSettings>
     </Parser>


### PR DESCRIPTION
The complex version would supply presets from a dropdown, or allow
users to configure it with a Custom option. Presets would be 'Symbols'
and 'Numbers'. I abandoned this when it increased complexity by about
tenfold. May return to it if I can find a way to simplify them.

Fixes Issue #36